### PR TITLE
Separate the client application and server

### DIFF
--- a/cli-app/build.gradle
+++ b/cli-app/build.gradle
@@ -20,6 +20,7 @@
 
 dependencies {
     compile group: 'org.jline', name: 'jline', version: '3.3.0'
+    compile group: 'io.spine', name: 'jdbc-rdbms', version: spineVersion
 
     compile project(path: ':api-java')
     compile project(path: ':client')
@@ -28,8 +29,8 @@ dependencies {
     testCompile project(path: ':testutil-api')
 }
 
-task runTodoList(dependsOn: jar, type: JavaExec) {
+task runTodoClient(dependsOn: jar, type: JavaExec) {
     standardInput = System.in
-    main = 'io.spine.examples.todolist.CliEntryPoint'
+    main = 'io.spine.examples.todolist.ClientApp'
     classpath = sourceSets.main.runtimeClasspath
 }

--- a/cli-app/src/main/java/io/spine/examples/todolist/AppConfig.java
+++ b/cli-app/src/main/java/io/spine/examples/todolist/AppConfig.java
@@ -22,43 +22,27 @@ package io.spine.examples.todolist;
 
 import io.spine.examples.todolist.client.CommandLineTodoClient;
 import io.spine.examples.todolist.client.TodoClient;
-import io.spine.examples.todolist.context.BoundedContexts;
 import io.spine.examples.todolist.server.Server;
-import io.spine.server.BoundedContext;
 
 import static io.spine.client.ConnectionConstants.DEFAULT_CLIENT_SERVICE_PORT;
 import static io.spine.examples.todolist.client.CommandLineTodoClient.HOST;
 
 /**
- * Configuration of the application.
+ * Configuration of the client application.
  *
  * @author Dmytro Grankin
  */
 public class AppConfig {
 
-    static final int PORT = DEFAULT_CLIENT_SERVICE_PORT;
-    private static final BoundedContext BOUNDED_CONTEXT = BoundedContexts.create();
-
-    private static final Server SERVER = new Server(PORT, BOUNDED_CONTEXT);
-    private static final TodoClient CLIENT = new CommandLineTodoClient(HOST, PORT);
+    private static final TodoClient CLIENT = new CommandLineTodoClient(HOST,
+                                                                       DEFAULT_CLIENT_SERVICE_PORT);
 
     private AppConfig() {
         // Prevent instantiation of this class.
     }
 
     /**
-     * Obtains the {@link Server} instance.
-     *
-     * <p>Initially is not started.
-     *
-     * @return the server
-     */
-    static Server getServer() {
-        return SERVER;
-    }
-
-    /**
-     * Obtains {@link TodoClient} for communication with the {@linkplain #getServer() server}.
+     * Obtains {@link TodoClient} for communication with the {@link Server}.
      *
      * @return the client interface
      */

--- a/cli-app/src/main/java/io/spine/examples/todolist/AppConfig.java
+++ b/cli-app/src/main/java/io/spine/examples/todolist/AppConfig.java
@@ -40,7 +40,7 @@ public class AppConfig {
     private static final BoundedContext BOUNDED_CONTEXT = BoundedContexts.create();
 
     private static final Server SERVER = new Server(PORT, BOUNDED_CONTEXT);
-    private static final TodoClient CLIENT = new CommandLineTodoClient(HOST, PORT, BOUNDED_CONTEXT);
+    private static final TodoClient CLIENT = new CommandLineTodoClient(HOST, PORT);
 
     private AppConfig() {
         // Prevent instantiation of this class.

--- a/cli-app/src/main/java/io/spine/examples/todolist/ClientApp.java
+++ b/cli-app/src/main/java/io/spine/examples/todolist/ClientApp.java
@@ -24,58 +24,36 @@ import com.google.common.annotations.VisibleForTesting;
 import io.spine.cli.Application;
 import io.spine.cli.Screen;
 import io.spine.cli.view.View;
-import io.spine.examples.todolist.server.Server;
 import io.spine.examples.todolist.view.MainMenu;
 
-import java.io.IOException;
-
 import static io.spine.examples.todolist.AppConfig.getClient;
-import static io.spine.examples.todolist.AppConfig.getServer;
-import static io.spine.util.Exceptions.illegalStateWithCauseOf;
 
 /**
- * Entry point to the command-line application.
+ * A command-line client application.
  *
- * <p>To run application from command-line, use the following command:
- * <pre>{@code gradle runTodoList}</pre>
+ * <p>To run the application from a command-line, use the following command:
+ * <pre>{@code gradle runTodoClient}</pre>
  *
  * @author Illia Shepilov
  */
-public class CliEntryPoint {
+public class ClientApp {
 
-    private CliEntryPoint() {
+    private ClientApp() {
         // Prevent instantiation of this class.
     }
 
     public static void main(String[] args) {
-        final Server server = getServer();
-        startServer(server);
-
         final Screen screen = new TerminalScreen();
         initCli(screen);
         final View entryPoint = MainMenu.create();
         screen.renderView(entryPoint);
 
         getClient().shutdown();
-        server.shutdown();
     }
 
     @VisibleForTesting
     static void initCli(Screen screen) {
         Application.getInstance()
                    .init(screen);
-    }
-
-    @VisibleForTesting
-    static void startServer(Server server) {
-        final Thread serverThread = new Thread(() -> {
-            try {
-                server.start();
-            } catch (IOException e) {
-                throw illegalStateWithCauseOf(e);
-            }
-        });
-
-        serverThread.start();
     }
 }

--- a/cli-app/src/main/java/io/spine/examples/todolist/LocalServer.java
+++ b/cli-app/src/main/java/io/spine/examples/todolist/LocalServer.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.todolist;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import io.spine.examples.todolist.context.BoundedContexts;
+import io.spine.examples.todolist.server.Server;
+import io.spine.server.BoundedContext;
+import io.spine.server.storage.StorageFactory;
+import io.spine.server.storage.jdbc.JdbcStorageFactory;
+import io.spine.server.storage.jdbc.type.JdbcTypeRegistryFactory;
+
+import javax.sql.DataSource;
+import java.io.IOException;
+
+import static io.spine.Identifier.newUuid;
+import static io.spine.client.ConnectionConstants.DEFAULT_CLIENT_SERVICE_PORT;
+
+/**
+ * A local {@link Server} using {@link io.spine.server.storage.jdbc.JdbcStorageFactory}.
+ *
+ * @author Dmytro Grankin
+ */
+public class LocalServer {
+
+    private static final String HSQL_IN_MEMORY_DB_URL_PREFIX = "jdbc:hsqldb:mem:";
+    private static final String DB_NAME = "TodoListInMemoryDB";
+
+    private LocalServer() {
+        // Prevent instantiation of this class.
+    }
+
+    public static void main(String[] args) throws IOException {
+        final BoundedContext boundedContext = createBoundedContext();
+        final Server server = new Server(DEFAULT_CLIENT_SERVICE_PORT, boundedContext);
+        server.start();
+    }
+
+    @VisibleForTesting
+    static BoundedContext createBoundedContext() {
+        final StorageFactory storageFactory = createStorageFactory();
+        return BoundedContexts.create(storageFactory);
+    }
+
+    private static StorageFactory createStorageFactory() {
+        return JdbcStorageFactory.newBuilder()
+                                 .setDataSource(inMemoryDataSource())
+                                 .setColumnTypeRegistry(JdbcTypeRegistryFactory.defaultInstance())
+                                 .setMultitenant(false)
+                                 .build();
+    }
+
+    private static DataSource inMemoryDataSource() {
+        final HikariConfig config = new HikariConfig();
+        final String dbUrl = HSQL_IN_MEMORY_DB_URL_PREFIX + DB_NAME + newUuid();
+        config.setJdbcUrl(dbUrl);
+
+        // Not setting username and password is OK for in-memory database.
+        final DataSource dataSource = new HikariDataSource(config);
+        return dataSource;
+    }
+}

--- a/cli-app/src/test/java/io/spine/examples/todolist/ClientAppTest.java
+++ b/cli-app/src/test/java/io/spine/examples/todolist/ClientAppTest.java
@@ -22,32 +22,21 @@ package io.spine.examples.todolist;
 
 import io.spine.cli.Application;
 import io.spine.cli.Screen;
-import io.spine.examples.todolist.context.BoundedContexts;
-import io.spine.examples.todolist.server.Server;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.client.ConnectionConstants.DEFAULT_CLIENT_SERVICE_PORT;
-import static io.spine.examples.todolist.CliEntryPoint.initCli;
-import static io.spine.examples.todolist.CliEntryPoint.startServer;
+import static io.spine.examples.todolist.ClientApp.initCli;
 import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
 import static io.spine.test.Tests.nullRef;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@DisplayName("CliEntryPoint should")
-class CliEntryPointTest {
+@DisplayName("ClientApp should")
+class ClientAppTest {
 
     @Test
     @DisplayName("have the private constructor")
     void havePrivateCtor() {
-        assertHasPrivateParameterlessCtor(CliEntryPoint.class);
-    }
-
-    @Test
-    @DisplayName("start the server properly")
-    void startServerProperly() {
-        final Server server = new Server(DEFAULT_CLIENT_SERVICE_PORT, BoundedContexts.create());
-        startServer(server);
+        assertHasPrivateParameterlessCtor(ClientApp.class);
     }
 
     @Test

--- a/cli-app/src/test/java/io/spine/examples/todolist/LocalServerTest.java
+++ b/cli-app/src/test/java/io/spine/examples/todolist/LocalServerTest.java
@@ -20,20 +20,29 @@
 
 package io.spine.examples.todolist;
 
+import io.spine.server.BoundedContext;
+import io.spine.server.storage.StorageFactory;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static io.spine.examples.todolist.LocalServer.createBoundedContext;
 import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
+import static org.junit.Assert.assertFalse;
 
-/**
- * @author Dmytro Grankin
- */
-@DisplayName("AppConfig should")
-class AppConfigTest {
+@DisplayName("LocalServer should")
+class LocalServerTest {
 
     @Test
     @DisplayName("have the private constructor")
     void havePrivateCtor() {
-        assertHasPrivateParameterlessCtor(AppConfig.class);
+        assertHasPrivateParameterlessCtor(LocalServer.class);
+    }
+
+    @Test
+    @DisplayName("create signletenant BoundedContext")
+    void createSingletenantBoundedContext() {
+        final BoundedContext boundedContext = createBoundedContext();
+        final StorageFactory storageFactory = boundedContext.getStorageFactory();
+        assertFalse(storageFactory.isMultitenant());
     }
 }

--- a/cli-app/src/test/java/io/spine/examples/todolist/view/MainMenuTest.java
+++ b/cli-app/src/test/java/io/spine/examples/todolist/view/MainMenuTest.java
@@ -29,7 +29,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * @author Dmytro Grankin
  */
 @DisplayName("MainMenu should")
-class MainMenuTest {
+class MainMenuTest extends ViewTest {
 
     @Test
     @DisplayName("not be empty")

--- a/cli-app/src/test/java/io/spine/examples/todolist/view/MyTasksListViewTest.java
+++ b/cli-app/src/test/java/io/spine/examples/todolist/view/MyTasksListViewTest.java
@@ -47,19 +47,14 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
  * @author Dmytro Grankin
  */
 @DisplayName("MyTasksListView should")
-class MyTasksListViewTest {
+class MyTasksListViewTest extends ViewTest {
 
     private static final int VIEW_INDEX = 0;
 
-    private Bot bot;
+    private final Bot bot = new Bot();
     private final TaskItem taskView = TaskItem.newBuilder()
                                               .setDescription(newDescription("task desc"))
                                               .build();
-
-    @BeforeEach
-    void setUp() {
-        bot = new Bot();
-    }
 
     @Test
     @DisplayName("refresh task list")

--- a/cli-app/src/test/java/io/spine/examples/todolist/view/NewTaskViewTest.java
+++ b/cli-app/src/test/java/io/spine/examples/todolist/view/NewTaskViewTest.java
@@ -42,19 +42,14 @@ import static org.junit.jupiter.api.Assertions.assertNotEquals;
  * @author Dmytro Grankin
  */
 @DisplayName("NewTaskView should")
-class NewTaskViewTest {
+class NewTaskViewTest extends ViewTest {
 
     private static final String ACTION_NAME = "quit";
     private static final Shortcut QUIT_SHORTCUT = new Shortcut("q");
     private static final TaskDescription VALID_DESCRIPTION = newDescription("task description");
 
-    private Bot bot;
+    private final Bot bot = new Bot();
     private final NewTaskView view = NewTaskView.create();
-
-    @BeforeEach
-    void setUp() {
-        bot = new Bot();
-    }
 
     @Test
     @DisplayName("handle empty description")

--- a/cli-app/src/test/java/io/spine/examples/todolist/view/TaskViewTest.java
+++ b/cli-app/src/test/java/io/spine/examples/todolist/view/TaskViewTest.java
@@ -40,7 +40,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  * @author Dmytro Grankin
  */
 @DisplayName("TaskView should")
-class TaskViewTest {
+class TaskViewTest extends ViewTest {
 
     private final TaskItem task = TaskItem.newBuilder()
                                           .setDescription(newDescription("my task description"))

--- a/cli-app/src/test/java/io/spine/examples/todolist/view/ViewTest.java
+++ b/cli-app/src/test/java/io/spine/examples/todolist/view/ViewTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2017, TeamDev Ltd. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.todolist.view;
+
+import io.spine.examples.todolist.context.BoundedContexts;
+import io.spine.examples.todolist.server.Server;
+import io.spine.server.BoundedContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static io.spine.client.ConnectionConstants.DEFAULT_CLIENT_SERVICE_PORT;
+import static io.spine.util.Exceptions.illegalStateWithCauseOf;
+
+/**
+ * @author Dmytro Grankin
+ */
+abstract class ViewTest {
+
+    private static final int PORT = DEFAULT_CLIENT_SERVICE_PORT;
+
+    private Server server;
+
+    @BeforeEach
+    void setUp() throws InterruptedException {
+        final BoundedContext boundedContext = BoundedContexts.create();
+        server = new Server(PORT, boundedContext);
+        startServer();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        server.shutdown();
+    }
+
+    private void startServer() throws InterruptedException {
+        final CountDownLatch serverStartLatch = new CountDownLatch(1);
+        final Thread serverThread = new Thread(() -> {
+            try {
+                server.start();
+                serverStartLatch.countDown();
+            } catch (IOException e) {
+                throw illegalStateWithCauseOf(e);
+            }
+        });
+
+        serverThread.start();
+        serverStartLatch.await(100, TimeUnit.MILLISECONDS);
+    }
+}

--- a/client/src/test/java/io/spine/examples/todolist/client/CommandLineTodoClientTest.java
+++ b/client/src/test/java/io/spine/examples/todolist/client/CommandLineTodoClientTest.java
@@ -66,7 +66,7 @@ abstract class CommandLineTodoClientTest {
     }
 
     @AfterEach
-    public void tearDown() throws Exception {
+    public void tearDown() {
         server.shutdown();
         getClient().shutdown();
     }

--- a/client/src/test/java/io/spine/examples/todolist/client/CommandLineTodoClientTest.java
+++ b/client/src/test/java/io/spine/examples/todolist/client/CommandLineTodoClientTest.java
@@ -62,7 +62,7 @@ abstract class CommandLineTodoClientTest {
         final BoundedContext boundedContext = BoundedContexts.create();
         server = new Server(PORT, boundedContext);
         startServer();
-        client = new CommandLineTodoClient(HOST, PORT, boundedContext);
+        client = new CommandLineTodoClient(HOST, PORT);
     }
 
     @AfterEach

--- a/ext.gradle
+++ b/ext.gradle
@@ -19,7 +19,7 @@
  */
 
 
-final def SPINE_VERSION = '0.9.60-SNAPSHOT'
+final def SPINE_VERSION = '0.9.64-SNAPSHOT'
 
 project.ext {
     // TODOList version


### PR DESCRIPTION
This PR separates `CliEntryPoint` into `ClientApp` and `LocalServer`. The server uses `JdbcStorageFactory`, which produces in-memory storages.

Other changes:
- `BoundedContext` was removed from `CommandLineTodoClient`. The client uses the blocking stub for querying instead.
- Spine version increased to `0.9.64-SNAPSHOT`.