### PR TITLE
Rename failures to rejections

### DIFF
--- a/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/LabelAggregate.java
+++ b/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/LabelAggregate.java
@@ -33,7 +33,7 @@ import io.spine.examples.todolist.c.commands.CreateBasicLabel;
 import io.spine.examples.todolist.c.commands.UpdateLabelDetails;
 import io.spine.examples.todolist.c.events.LabelCreated;
 import io.spine.examples.todolist.c.events.LabelDetailsUpdated;
-import io.spine.examples.todolist.c.failures.CannotUpdateLabelDetails;
+import io.spine.examples.todolist.c.rejection.CannotUpdateLabelDetails;
 import io.spine.server.aggregate.Aggregate;
 import io.spine.server.aggregate.Apply;
 import io.spine.server.command.Assign;
@@ -41,7 +41,7 @@ import io.spine.server.command.Assign;
 import java.util.Collections;
 import java.util.List;
 
-import static io.spine.examples.todolist.c.aggregate.failures.LabelAggregateFailures.throwCannotUpdateLabelDetailsFailure;
+import static io.spine.examples.todolist.c.aggregate.rejection.LabelAggregateRejections.throwCannotUpdateLabelDetails;
 
 /**
  * The aggregate managing the state of a {@link TaskLabel}.
@@ -92,7 +92,7 @@ public class LabelAggregate extends Aggregate<LabelId, TaskLabel, TaskLabelVBuil
             final LabelDetails newLabelDetails = labelDetailsChange.getNewDetails();
             final ValueMismatch mismatch = unexpectedValue(expectedLabelDetails,
                                                            actualLabelDetails, newLabelDetails);
-            throwCannotUpdateLabelDetailsFailure(cmd, mismatch);
+            throwCannotUpdateLabelDetails(cmd, mismatch);
         }
 
         final LabelId labelId = cmd.getId();

--- a/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/TaskLabelsPart.java
+++ b/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/TaskLabelsPart.java
@@ -31,8 +31,8 @@ import io.spine.examples.todolist.c.commands.AssignLabelToTask;
 import io.spine.examples.todolist.c.commands.RemoveLabelFromTask;
 import io.spine.examples.todolist.c.events.LabelAssignedToTask;
 import io.spine.examples.todolist.c.events.LabelRemovedFromTask;
-import io.spine.examples.todolist.c.failures.CannotAssignLabelToTask;
-import io.spine.examples.todolist.c.failures.CannotRemoveLabelFromTask;
+import io.spine.examples.todolist.c.rejection.CannotAssignLabelToTask;
+import io.spine.examples.todolist.c.rejection.CannotRemoveLabelFromTask;
 import io.spine.server.aggregate.AggregatePart;
 import io.spine.server.aggregate.Apply;
 import io.spine.server.command.Assign;
@@ -43,8 +43,8 @@ import java.util.List;
 
 import static io.spine.examples.todolist.c.aggregate.TaskFlowValidator.isValidAssignLabelToTaskCommand;
 import static io.spine.examples.todolist.c.aggregate.TaskFlowValidator.isValidTaskStatusToRemoveLabel;
-import static io.spine.examples.todolist.c.aggregate.failures.TaskLabelsPartFailures.throwCannotAssignLabelToTaskFailure;
-import static io.spine.examples.todolist.c.aggregate.failures.TaskLabelsPartFailures.throwCannotRemoveLabelFromTaskFailure;
+import static io.spine.examples.todolist.c.aggregate.rejection.TaskLabelsPartRejections.throwCannotAssignLabelToTask;
+import static io.spine.examples.todolist.c.aggregate.rejection.TaskLabelsPartRejections.throwCannotRemoveLabelFromTask;
 import static java.util.Collections.singletonList;
 
 /**
@@ -77,7 +77,7 @@ public class TaskLabelsPart
                                                   .contains(labelId);
         final boolean isValidTaskStatus = isValidTaskStatusToRemoveLabel(taskState.getTaskStatus());
         if (!isLabelAssigned || !isValidTaskStatus) {
-            throwCannotRemoveLabelFromTaskFailure(cmd);
+            throwCannotRemoveLabelFromTask(cmd);
         }
 
         final LabelRemovedFromTask labelRemoved = LabelRemovedFromTask.newBuilder()
@@ -96,7 +96,7 @@ public class TaskLabelsPart
         final boolean isValid = isValidAssignLabelToTaskCommand(state.getTaskStatus());
 
         if (!isValid) {
-            throwCannotAssignLabelToTaskFailure(cmd);
+            throwCannotAssignLabelToTask(cmd);
         }
 
         final LabelAssignedToTask labelAssigned = LabelAssignedToTask.newBuilder()

--- a/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/TaskPart.java
+++ b/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/TaskPart.java
@@ -56,15 +56,15 @@ import io.spine.examples.todolist.c.events.TaskDraftFinalized;
 import io.spine.examples.todolist.c.events.TaskDueDateUpdated;
 import io.spine.examples.todolist.c.events.TaskPriorityUpdated;
 import io.spine.examples.todolist.c.events.TaskReopened;
-import io.spine.examples.todolist.c.failures.CannotCompleteTask;
-import io.spine.examples.todolist.c.failures.CannotCreateDraft;
-import io.spine.examples.todolist.c.failures.CannotDeleteTask;
-import io.spine.examples.todolist.c.failures.CannotFinalizeDraft;
-import io.spine.examples.todolist.c.failures.CannotReopenTask;
-import io.spine.examples.todolist.c.failures.CannotRestoreDeletedTask;
-import io.spine.examples.todolist.c.failures.CannotUpdateTaskDescription;
-import io.spine.examples.todolist.c.failures.CannotUpdateTaskDueDate;
-import io.spine.examples.todolist.c.failures.CannotUpdateTaskPriority;
+import io.spine.examples.todolist.c.rejection.CannotCompleteTask;
+import io.spine.examples.todolist.c.rejection.CannotCreateDraft;
+import io.spine.examples.todolist.c.rejection.CannotDeleteTask;
+import io.spine.examples.todolist.c.rejection.CannotFinalizeDraft;
+import io.spine.examples.todolist.c.rejection.CannotReopenTask;
+import io.spine.examples.todolist.c.rejection.CannotRestoreDeletedTask;
+import io.spine.examples.todolist.c.rejection.CannotUpdateTaskDescription;
+import io.spine.examples.todolist.c.rejection.CannotUpdateTaskDueDate;
+import io.spine.examples.todolist.c.rejection.CannotUpdateTaskPriority;
 import io.spine.server.aggregate.AggregatePart;
 import io.spine.server.aggregate.Apply;
 import io.spine.server.command.Assign;
@@ -80,16 +80,16 @@ import static io.spine.examples.todolist.c.aggregate.TaskFlowValidator.isValidCr
 import static io.spine.examples.todolist.c.aggregate.TaskFlowValidator.isValidTransition;
 import static io.spine.examples.todolist.c.aggregate.TaskFlowValidator.isValidUpdateTaskDueDateCommand;
 import static io.spine.examples.todolist.c.aggregate.TaskFlowValidator.isValidUpdateTaskPriorityCommand;
-import static io.spine.examples.todolist.c.aggregate.failures.TaskPartFailures.ChangeStatusFailures.throwCannotCompleteTask;
-import static io.spine.examples.todolist.c.aggregate.failures.TaskPartFailures.ChangeStatusFailures.throwCannotDeleteTask;
-import static io.spine.examples.todolist.c.aggregate.failures.TaskPartFailures.ChangeStatusFailures.throwCannotFinalizeDraft;
-import static io.spine.examples.todolist.c.aggregate.failures.TaskPartFailures.ChangeStatusFailures.throwCannotReopenTask;
-import static io.spine.examples.todolist.c.aggregate.failures.TaskPartFailures.ChangeStatusFailures.throwCannotRestoreDeletedTask;
-import static io.spine.examples.todolist.c.aggregate.failures.TaskPartFailures.TaskCreationFailures.throwCannotCreateDraftFailure;
-import static io.spine.examples.todolist.c.aggregate.failures.TaskPartFailures.UpdateFailures.throwCannotUpdateDescription;
-import static io.spine.examples.todolist.c.aggregate.failures.TaskPartFailures.UpdateFailures.throwCannotUpdateTaskDescription;
-import static io.spine.examples.todolist.c.aggregate.failures.TaskPartFailures.UpdateFailures.throwCannotUpdateTaskDueDate;
-import static io.spine.examples.todolist.c.aggregate.failures.TaskPartFailures.UpdateFailures.throwCannotUpdateTaskPriority;
+import static io.spine.examples.todolist.c.aggregate.rejection.TaskPartRejections.ChangeStatusRejections.throwCannotCompleteTask;
+import static io.spine.examples.todolist.c.aggregate.rejection.TaskPartRejections.ChangeStatusRejections.throwCannotDeleteTask;
+import static io.spine.examples.todolist.c.aggregate.rejection.TaskPartRejections.ChangeStatusRejections.throwCannotFinalizeDraft;
+import static io.spine.examples.todolist.c.aggregate.rejection.TaskPartRejections.ChangeStatusRejections.throwCannotReopenTask;
+import static io.spine.examples.todolist.c.aggregate.rejection.TaskPartRejections.ChangeStatusRejections.throwCannotRestoreDeletedTask;
+import static io.spine.examples.todolist.c.aggregate.rejection.TaskPartRejections.TaskCreationRejections.throwCannotCreateDraft;
+import static io.spine.examples.todolist.c.aggregate.rejection.TaskPartRejections.UpdateRejections.throwCannotUpdateDescription;
+import static io.spine.examples.todolist.c.aggregate.rejection.TaskPartRejections.UpdateRejections.throwCannotUpdateTaskDescription;
+import static io.spine.examples.todolist.c.aggregate.rejection.TaskPartRejections.UpdateRejections.throwCannotUpdateTaskDueDate;
+import static io.spine.examples.todolist.c.aggregate.rejection.TaskPartRejections.UpdateRejections.throwCannotUpdateTaskPriority;
 import static io.spine.time.Time.getCurrentTime;
 import static io.spine.time.Timestamps2.compare;
 import static java.util.Collections.singletonList;
@@ -288,7 +288,7 @@ public class TaskPart extends AggregatePart<TaskId,
         final boolean isValid = isValidCreateDraftCommand(getState().getTaskStatus());
 
         if (!isValid) {
-            throwCannotCreateDraftFailure(cmd);
+            throwCannotCreateDraft(cmd);
         }
 
         final TaskId taskId = cmd.getId();

--- a/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/rejection/LabelAggregateRejections.java
+++ b/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/rejection/LabelAggregateRejections.java
@@ -18,35 +18,35 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.examples.todolist.c.aggregate.failures;
+package io.spine.examples.todolist.c.aggregate.rejection;
 
 import io.spine.examples.todolist.c.aggregate.LabelAggregate;
 import io.spine.change.ValueMismatch;
 import io.spine.examples.todolist.FailedLabelCommandDetails;
 import io.spine.examples.todolist.LabelDetailsUpdateFailed;
 import io.spine.examples.todolist.c.commands.UpdateLabelDetails;
-import io.spine.examples.todolist.c.failures.CannotUpdateLabelDetails;
+import io.spine.examples.todolist.c.rejection.CannotUpdateLabelDetails;
 
 /**
- * Utility class for working with {@link LabelAggregate} failures.
+ * Utility class for working with {@link LabelAggregate} rejection.
  *
  * @author Illia Shepilov
  */
-public class LabelAggregateFailures {
+public class LabelAggregateRejections {
 
-    private LabelAggregateFailures() {
+    private LabelAggregateRejections() {
     }
 
     /**
-     * Constructs and throws the {@link CannotUpdateLabelDetails} failure according to
+     * Constructs and throws the {@link CannotUpdateLabelDetails} rejection according to
      * the passed parameters.
      *
      * @param cmd      the failed command
      * @param mismatch the {@link ValueMismatch}
-     * @throws CannotUpdateLabelDetails the failure to throw
+     * @throws CannotUpdateLabelDetails the rejection to throw
      */
-    public static void throwCannotUpdateLabelDetailsFailure(UpdateLabelDetails cmd,
-                                                            ValueMismatch mismatch)
+    public static void throwCannotUpdateLabelDetails(UpdateLabelDetails cmd,
+                                                     ValueMismatch mismatch)
             throws CannotUpdateLabelDetails {
         final FailedLabelCommandDetails labelCommandFailed =
                 FailedLabelCommandDetails.newBuilder()
@@ -54,7 +54,7 @@ public class LabelAggregateFailures {
                                          .build();
         final LabelDetailsUpdateFailed labelDetailsUpdateFailed =
                 LabelDetailsUpdateFailed.newBuilder()
-                                        .setFailureDetails(labelCommandFailed)
+                                        .setRejectionDetails(labelCommandFailed)
                                         .setLabelDetailsMismatch(mismatch)
                                         .build();
         throw new CannotUpdateLabelDetails(labelDetailsUpdateFailed);

--- a/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/rejection/LabelAggregateRejections.java
+++ b/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/rejection/LabelAggregateRejections.java
@@ -20,10 +20,10 @@
 
 package io.spine.examples.todolist.c.aggregate.rejection;
 
-import io.spine.examples.todolist.c.aggregate.LabelAggregate;
 import io.spine.change.ValueMismatch;
-import io.spine.examples.todolist.FailedLabelCommandDetails;
-import io.spine.examples.todolist.LabelDetailsUpdateFailed;
+import io.spine.examples.todolist.LabelDetailsUpdateRejected;
+import io.spine.examples.todolist.RejectedLabelCommandDetails;
+import io.spine.examples.todolist.c.aggregate.LabelAggregate;
 import io.spine.examples.todolist.c.commands.UpdateLabelDetails;
 import io.spine.examples.todolist.c.rejection.CannotUpdateLabelDetails;
 
@@ -41,22 +41,22 @@ public class LabelAggregateRejections {
      * Constructs and throws the {@link CannotUpdateLabelDetails} rejection according to
      * the passed parameters.
      *
-     * @param cmd      the failed command
+     * @param cmd      the rejected command
      * @param mismatch the {@link ValueMismatch}
      * @throws CannotUpdateLabelDetails the rejection to throw
      */
     public static void throwCannotUpdateLabelDetails(UpdateLabelDetails cmd,
                                                      ValueMismatch mismatch)
             throws CannotUpdateLabelDetails {
-        final FailedLabelCommandDetails labelCommandFailed =
-                FailedLabelCommandDetails.newBuilder()
-                                         .setLabelId(cmd.getId())
-                                         .build();
-        final LabelDetailsUpdateFailed labelDetailsUpdateFailed =
-                LabelDetailsUpdateFailed.newBuilder()
-                                        .setRejectionDetails(labelCommandFailed)
-                                        .setLabelDetailsMismatch(mismatch)
-                                        .build();
-        throw new CannotUpdateLabelDetails(labelDetailsUpdateFailed);
+        final RejectedLabelCommandDetails labelCommandRejected =
+                RejectedLabelCommandDetails.newBuilder()
+                                           .setLabelId(cmd.getId())
+                                           .build();
+        final LabelDetailsUpdateRejected detailsUpdateRejected =
+                LabelDetailsUpdateRejected.newBuilder()
+                                          .setRejectionDetails(labelCommandRejected)
+                                          .setLabelDetailsMismatch(mismatch)
+                                          .build();
+        throw new CannotUpdateLabelDetails(detailsUpdateRejected);
     }
 }

--- a/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/rejection/LabelAggregateRejections.java
+++ b/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/rejection/LabelAggregateRejections.java
@@ -48,13 +48,13 @@ public class LabelAggregateRejections {
     public static void throwCannotUpdateLabelDetails(UpdateLabelDetails cmd,
                                                      ValueMismatch mismatch)
             throws CannotUpdateLabelDetails {
-        final RejectedLabelCommandDetails labelCommandRejected =
+        final RejectedLabelCommandDetails commandDetails =
                 RejectedLabelCommandDetails.newBuilder()
                                            .setLabelId(cmd.getId())
                                            .build();
         final LabelDetailsUpdateRejected detailsUpdateRejected =
                 LabelDetailsUpdateRejected.newBuilder()
-                                          .setRejectionDetails(labelCommandRejected)
+                                          .setCommandDetails(commandDetails)
                                           .setLabelDetailsMismatch(mismatch)
                                           .build();
         throw new CannotUpdateLabelDetails(detailsUpdateRejected);

--- a/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/rejection/TaskLabelsPartRejections.java
+++ b/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/rejection/TaskLabelsPartRejections.java
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.examples.todolist.c.aggregate.failures;
+package io.spine.examples.todolist.c.aggregate.rejection;
 
 import io.spine.examples.todolist.AssignLabelToTaskFailed;
 import io.spine.examples.todolist.FailedTaskCommandDetails;
@@ -26,27 +26,27 @@ import io.spine.examples.todolist.RemoveLabelFromTaskFailed;
 import io.spine.examples.todolist.c.aggregate.TaskLabelsPart;
 import io.spine.examples.todolist.c.commands.AssignLabelToTask;
 import io.spine.examples.todolist.c.commands.RemoveLabelFromTask;
-import io.spine.examples.todolist.c.failures.CannotAssignLabelToTask;
-import io.spine.examples.todolist.c.failures.CannotRemoveLabelFromTask;
+import io.spine.examples.todolist.c.rejection.CannotAssignLabelToTask;
+import io.spine.examples.todolist.c.rejection.CannotRemoveLabelFromTask;
 
 /**
- * Utility class for working with {@link TaskLabelsPart} failures.
+ * Utility class for working with {@link TaskLabelsPart} rejection.
  *
  * @author Illia Shepilov
  */
-public class TaskLabelsPartFailures {
+public class TaskLabelsPartRejections {
 
-    private TaskLabelsPartFailures() {
+    private TaskLabelsPartRejections() {
     }
 
     /**
-     * Constructs and throws the {@link CannotAssignLabelToTask} failure according to
+     * Constructs and throws the {@link CannotAssignLabelToTask} rejection according to
      * the passed parameters.
      *
-     * @param cmd the {@code AssignLabelToTask} command which thrown the failure
-     * @throws CannotAssignLabelToTask the failure to throw
+     * @param cmd the {@code AssignLabelToTask} command which thrown the rejection
+     * @throws CannotAssignLabelToTask the rejection to throw
      */
-    public static void throwCannotAssignLabelToTaskFailure(AssignLabelToTask cmd)
+    public static void throwCannotAssignLabelToTask(AssignLabelToTask cmd)
             throws CannotAssignLabelToTask {
         final FailedTaskCommandDetails commandFailed =
                 FailedTaskCommandDetails.newBuilder()
@@ -54,20 +54,20 @@ public class TaskLabelsPartFailures {
                                         .build();
         final AssignLabelToTaskFailed assignLabelToTaskFailed =
                 AssignLabelToTaskFailed.newBuilder()
-                                       .setFailureDetails(commandFailed)
+                                       .setRejectionDetails(commandFailed)
                                        .setLabelId(cmd.getLabelId())
                                        .build();
         throw new CannotAssignLabelToTask(assignLabelToTaskFailed);
     }
 
     /**
-     * Constructs and throws the {@link CannotRemoveLabelFromTask} failure according to
+     * Constructs and throws the {@link CannotRemoveLabelFromTask} rejection according to
      * the passed parameters.
      *
-     * @param cmd the {@code AssignLabelToTask} command which thrown the failure
-     * @throws CannotRemoveLabelFromTask the failure to throw
+     * @param cmd the {@code AssignLabelToTask} command which thrown the rejection
+     * @throws CannotRemoveLabelFromTask the rejection to throw
      */
-    public static void throwCannotRemoveLabelFromTaskFailure(RemoveLabelFromTask cmd)
+    public static void throwCannotRemoveLabelFromTask(RemoveLabelFromTask cmd)
             throws CannotRemoveLabelFromTask {
         final FailedTaskCommandDetails commandFailed =
                 FailedTaskCommandDetails.newBuilder()
@@ -76,7 +76,7 @@ public class TaskLabelsPartFailures {
         final RemoveLabelFromTaskFailed removeLabelFromTaskFailed =
                 RemoveLabelFromTaskFailed.newBuilder()
                                          .setLabelId(cmd.getLabelId())
-                                         .setFailureDetails(commandFailed)
+                                         .setRejectionDetails(commandFailed)
                                          .build();
         throw new CannotRemoveLabelFromTask(removeLabelFromTaskFailed);
     }

--- a/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/rejection/TaskLabelsPartRejections.java
+++ b/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/rejection/TaskLabelsPartRejections.java
@@ -48,13 +48,13 @@ public class TaskLabelsPartRejections {
      */
     public static void throwCannotAssignLabelToTask(AssignLabelToTask cmd)
             throws CannotAssignLabelToTask {
-        final RejectedTaskCommandDetails commandRejected =
+        final RejectedTaskCommandDetails commandDetails =
                 RejectedTaskCommandDetails.newBuilder()
                                           .setTaskId(cmd.getId())
                                           .build();
         final AssignLabelToTaskRejected assignLabelToTaskRejected =
                 AssignLabelToTaskRejected.newBuilder()
-                                         .setRejectionDetails(commandRejected)
+                                         .setCommandDetails(commandDetails)
                                          .setLabelId(cmd.getLabelId())
                                          .build();
         throw new CannotAssignLabelToTask(assignLabelToTaskRejected);
@@ -69,14 +69,14 @@ public class TaskLabelsPartRejections {
      */
     public static void throwCannotRemoveLabelFromTask(RemoveLabelFromTask cmd)
             throws CannotRemoveLabelFromTask {
-        final RejectedTaskCommandDetails commandRejected =
+        final RejectedTaskCommandDetails commandDetails =
                 RejectedTaskCommandDetails.newBuilder()
                                           .setTaskId(cmd.getId())
                                           .build();
         final RemoveLabelFromTaskRejected removeLabelRejected =
                 RemoveLabelFromTaskRejected.newBuilder()
                                            .setLabelId(cmd.getLabelId())
-                                           .setRejectionDetails(commandRejected)
+                                           .setCommandDetails(commandDetails)
                                            .build();
         throw new CannotRemoveLabelFromTask(removeLabelRejected);
     }

--- a/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/rejection/TaskLabelsPartRejections.java
+++ b/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/rejection/TaskLabelsPartRejections.java
@@ -20,9 +20,9 @@
 
 package io.spine.examples.todolist.c.aggregate.rejection;
 
-import io.spine.examples.todolist.AssignLabelToTaskFailed;
-import io.spine.examples.todolist.FailedTaskCommandDetails;
-import io.spine.examples.todolist.RemoveLabelFromTaskFailed;
+import io.spine.examples.todolist.AssignLabelToTaskRejected;
+import io.spine.examples.todolist.RejectedTaskCommandDetails;
+import io.spine.examples.todolist.RemoveLabelFromTaskRejected;
 import io.spine.examples.todolist.c.aggregate.TaskLabelsPart;
 import io.spine.examples.todolist.c.commands.AssignLabelToTask;
 import io.spine.examples.todolist.c.commands.RemoveLabelFromTask;
@@ -48,16 +48,16 @@ public class TaskLabelsPartRejections {
      */
     public static void throwCannotAssignLabelToTask(AssignLabelToTask cmd)
             throws CannotAssignLabelToTask {
-        final FailedTaskCommandDetails commandFailed =
-                FailedTaskCommandDetails.newBuilder()
-                                        .setTaskId(cmd.getId())
-                                        .build();
-        final AssignLabelToTaskFailed assignLabelToTaskFailed =
-                AssignLabelToTaskFailed.newBuilder()
-                                       .setRejectionDetails(commandFailed)
-                                       .setLabelId(cmd.getLabelId())
-                                       .build();
-        throw new CannotAssignLabelToTask(assignLabelToTaskFailed);
+        final RejectedTaskCommandDetails commandRejected =
+                RejectedTaskCommandDetails.newBuilder()
+                                          .setTaskId(cmd.getId())
+                                          .build();
+        final AssignLabelToTaskRejected assignLabelToTaskRejected =
+                AssignLabelToTaskRejected.newBuilder()
+                                         .setRejectionDetails(commandRejected)
+                                         .setLabelId(cmd.getLabelId())
+                                         .build();
+        throw new CannotAssignLabelToTask(assignLabelToTaskRejected);
     }
 
     /**
@@ -69,15 +69,15 @@ public class TaskLabelsPartRejections {
      */
     public static void throwCannotRemoveLabelFromTask(RemoveLabelFromTask cmd)
             throws CannotRemoveLabelFromTask {
-        final FailedTaskCommandDetails commandFailed =
-                FailedTaskCommandDetails.newBuilder()
-                                        .setTaskId(cmd.getId())
-                                        .build();
-        final RemoveLabelFromTaskFailed removeLabelFromTaskFailed =
-                RemoveLabelFromTaskFailed.newBuilder()
-                                         .setLabelId(cmd.getLabelId())
-                                         .setRejectionDetails(commandFailed)
-                                         .build();
-        throw new CannotRemoveLabelFromTask(removeLabelFromTaskFailed);
+        final RejectedTaskCommandDetails commandRejected =
+                RejectedTaskCommandDetails.newBuilder()
+                                          .setTaskId(cmd.getId())
+                                          .build();
+        final RemoveLabelFromTaskRejected removeLabelRejected =
+                RemoveLabelFromTaskRejected.newBuilder()
+                                           .setLabelId(cmd.getLabelId())
+                                           .setRejectionDetails(commandRejected)
+                                           .build();
+        throw new CannotRemoveLabelFromTask(removeLabelRejected);
     }
 }

--- a/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/rejection/TaskPartRejections.java
+++ b/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/rejection/TaskPartRejections.java
@@ -18,7 +18,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.examples.todolist.c.aggregate.failures;
+package io.spine.examples.todolist.c.aggregate.rejection;
 
 import io.spine.change.ValueMismatch;
 import io.spine.examples.todolist.CompleteTaskFailed;
@@ -42,92 +42,92 @@ import io.spine.examples.todolist.c.commands.RestoreDeletedTask;
 import io.spine.examples.todolist.c.commands.UpdateTaskDescription;
 import io.spine.examples.todolist.c.commands.UpdateTaskDueDate;
 import io.spine.examples.todolist.c.commands.UpdateTaskPriority;
-import io.spine.examples.todolist.c.failures.CannotCompleteTask;
-import io.spine.examples.todolist.c.failures.CannotCreateDraft;
-import io.spine.examples.todolist.c.failures.CannotDeleteTask;
-import io.spine.examples.todolist.c.failures.CannotFinalizeDraft;
-import io.spine.examples.todolist.c.failures.CannotReopenTask;
-import io.spine.examples.todolist.c.failures.CannotRestoreDeletedTask;
-import io.spine.examples.todolist.c.failures.CannotUpdateTaskDescription;
-import io.spine.examples.todolist.c.failures.CannotUpdateTaskDueDate;
-import io.spine.examples.todolist.c.failures.CannotUpdateTaskPriority;
+import io.spine.examples.todolist.c.rejection.CannotCompleteTask;
+import io.spine.examples.todolist.c.rejection.CannotCreateDraft;
+import io.spine.examples.todolist.c.rejection.CannotDeleteTask;
+import io.spine.examples.todolist.c.rejection.CannotFinalizeDraft;
+import io.spine.examples.todolist.c.rejection.CannotReopenTask;
+import io.spine.examples.todolist.c.rejection.CannotRestoreDeletedTask;
+import io.spine.examples.todolist.c.rejection.CannotUpdateTaskDescription;
+import io.spine.examples.todolist.c.rejection.CannotUpdateTaskDueDate;
+import io.spine.examples.todolist.c.rejection.CannotUpdateTaskPriority;
 
 /**
- * Utility class for working with {@link TaskPart} failures.
+ * Utility class for working with {@link TaskPart} rejection.
  *
  * @author Illia Shepilov
  */
-public class TaskPartFailures {
+public class TaskPartRejections {
 
-    private TaskPartFailures() {
+    private TaskPartRejections() {
         // Prevent instantiation of this utility class.
     }
 
-    public static class UpdateFailures {
+    public static class UpdateRejections {
 
-        private UpdateFailures() {
+        private UpdateRejections() {
         }
 
         /**
-         * Constructs and throws the {@link CannotUpdateTaskDescription} failure
+         * Constructs and throws the {@link CannotUpdateTaskDescription} rejection
          * according to the passed parameters.
          *
-         * @param cmd the {@code UpdateTaskDescription} command which thrown the failure
-         * @throws CannotUpdateTaskDescription the failure to throw
+         * @param cmd the {@code UpdateTaskDescription} command which thrown the rejection
+         * @throws CannotUpdateTaskDescription the rejection to throw
          */
         public static void throwCannotUpdateTaskDescription(UpdateTaskDescription cmd)
                 throws CannotUpdateTaskDescription {
             final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
             final DescriptionUpdateFailed descriptionUpdateFailed =
                     DescriptionUpdateFailed.newBuilder()
-                                           .setFailureDetails(commandFailed)
+                                           .setRejectionDetails(commandFailed)
                                            .build();
             throw new CannotUpdateTaskDescription(descriptionUpdateFailed);
         }
 
         /**
-         * Constructs and throws the {@link CannotUpdateTaskDueDate} failure
+         * Constructs and throws the {@link CannotUpdateTaskDueDate} rejection
          * according to the passed parameters.
          *
-         * @param cmd the {@code UpdateTaskDueDate} command which thrown the failure
-         * @throws CannotUpdateTaskDueDate the failure to throw
+         * @param cmd the {@code UpdateTaskDueDate} command which thrown the rejection
+         * @throws CannotUpdateTaskDueDate the rejection to throw
          */
         public static void throwCannotUpdateTaskDueDate(UpdateTaskDueDate cmd)
                 throws CannotUpdateTaskDueDate {
             final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
             final TaskDueDateUpdateFailed dueDateUpdateFailed =
                     TaskDueDateUpdateFailed.newBuilder()
-                                           .setFailureDetails(commandFailed)
+                                           .setRejectionDetails(commandFailed)
                                            .build();
             throw new CannotUpdateTaskDueDate(dueDateUpdateFailed);
         }
 
         /**
-         * Constructs and throws the {@link CannotUpdateTaskDueDate} failure
+         * Constructs and throws the {@link CannotUpdateTaskDueDate} rejection
          * according to the passed parameters.
          *
-         * @param cmd      the {@code UpdateTaskDueDate} command which thrown the failure
+         * @param cmd      the {@code UpdateTaskDueDate} command which thrown the rejection
          * @param mismatch the {@link ValueMismatch}
-         * @throws CannotUpdateTaskDueDate the failure to throw
+         * @throws CannotUpdateTaskDueDate the rejection to throw
          */
         public static void throwCannotUpdateTaskDueDate(
                 UpdateTaskDueDate cmd, ValueMismatch mismatch) throws CannotUpdateTaskDueDate {
             final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
             final TaskDueDateUpdateFailed dueDateUpdateFailed =
                     TaskDueDateUpdateFailed.newBuilder()
-                                           .setFailureDetails(commandFailed)
+                                           .setRejectionDetails(commandFailed)
                                            .setDueDateMismatch(mismatch)
                                            .build();
             throw new CannotUpdateTaskDueDate(dueDateUpdateFailed);
         }
 
         /**
-         * Constructs and throws the {@link CannotUpdateTaskDescription} failure
+         * Constructs and throws the {@link CannotUpdateTaskDescription} rejection
          * according to the passed parameters.
          *
-         * @param cmd      the {@code UpdateTaskDescription} command which thrown the failure
+         * @param cmd      the {@code UpdateTaskDescription} command which thrown the rejection
          * @param mismatch the {@link ValueMismatch}
-         * @throws CannotUpdateTaskDescription the failure to throw
+         * @throws CannotUpdateTaskDescription the rejection to throw
          */
         public static void throwCannotUpdateDescription(
                 UpdateTaskDescription cmd, ValueMismatch mismatch)
@@ -135,153 +135,153 @@ public class TaskPartFailures {
             final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
             final DescriptionUpdateFailed descriptionUpdateFailed =
                     DescriptionUpdateFailed.newBuilder()
-                                           .setFailureDetails(commandFailed)
+                                           .setRejectionDetails(commandFailed)
                                            .setDescriptionMismatch(mismatch)
                                            .build();
             throw new CannotUpdateTaskDescription(descriptionUpdateFailed);
         }
 
         /**
-         * Constructs and throws the {@link CannotUpdateTaskPriority} failure
+         * Constructs and throws the {@link CannotUpdateTaskPriority} rejection
          * according to the passed parameters.
          *
-         * @param cmd      the {@code UpdateTaskPriority} command which thrown the failure
+         * @param cmd      the {@code UpdateTaskPriority} command which thrown the rejection
          * @param mismatch the {@link ValueMismatch}
-         * @throws CannotUpdateTaskPriority the failure to throw
+         * @throws CannotUpdateTaskPriority the rejection to throw
          */
         public static void throwCannotUpdateTaskPriority(
                 UpdateTaskPriority cmd, ValueMismatch mismatch) throws CannotUpdateTaskPriority {
             final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
             final PriorityUpdateFailed priorityUpdateFailed =
                     PriorityUpdateFailed.newBuilder()
-                                        .setFailureDetails(commandFailed)
+                                        .setRejectionDetails(commandFailed)
                                         .setPriorityMismatch(mismatch)
                                         .build();
             throw new CannotUpdateTaskPriority(priorityUpdateFailed);
         }
 
         /**
-         * Constructs and throws the {@link CannotUpdateTaskPriority} failure
+         * Constructs and throws the {@link CannotUpdateTaskPriority} rejection
          * according to the passed parameters.
          *
-         * @param cmd the {@code UpdateTaskPriority} command which thrown the failure
-         * @throws CannotUpdateTaskPriority the failure to throw
+         * @param cmd the {@code UpdateTaskPriority} command which thrown the rejection
+         * @throws CannotUpdateTaskPriority the rejection to throw
          */
         public static void throwCannotUpdateTaskPriority(UpdateTaskPriority cmd)
                 throws CannotUpdateTaskPriority {
             final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
             final PriorityUpdateFailed priorityUpdateFailed =
                     PriorityUpdateFailed.newBuilder()
-                                        .setFailureDetails(commandFailed)
+                                        .setRejectionDetails(commandFailed)
                                         .build();
             throw new CannotUpdateTaskPriority(priorityUpdateFailed);
         }
     }
 
-    public static class TaskCreationFailures {
+    public static class TaskCreationRejections {
 
-        private TaskCreationFailures() {
+        private TaskCreationRejections() {
         }
 
         /**
-         * Constructs and throws the {@link CannotCreateDraft} failure
+         * Constructs and throws the {@link CannotCreateDraft} rejection
          * according to the passed parameters.
          *
-         * @param cmd the {@code CreateDraft} command which thrown the failure
-         * @throws CannotCreateDraft the failure to throw
+         * @param cmd the {@code CreateDraft} command which thrown the rejection
+         * @throws CannotCreateDraft the rejection to throw
          */
-        public static void throwCannotCreateDraftFailure(CreateDraft cmd) throws CannotCreateDraft {
+        public static void throwCannotCreateDraft(CreateDraft cmd) throws CannotCreateDraft {
             final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
             final CreateDraftFailed createDraftFailed =
                     CreateDraftFailed.newBuilder()
-                                     .setFailureDetails(commandFailed)
+                                     .setRejectionDetails(commandFailed)
                                      .build();
             throw new CannotCreateDraft(createDraftFailed);
         }
     }
 
-    public static class ChangeStatusFailures {
+    public static class ChangeStatusRejections {
 
-        private ChangeStatusFailures() {
+        private ChangeStatusRejections() {
         }
 
         /**
-         * Constructs and throws the {@link CannotReopenTask} failure
+         * Constructs and throws the {@link CannotReopenTask} rejection
          * according to the passed parameters.
          *
-         * @param cmd the {@code ReopenTask} command which thrown the failure
-         * @throws CannotReopenTask the failure to throw
+         * @param cmd the {@code ReopenTask} command which thrown the rejection
+         * @throws CannotReopenTask the rejection to throw
          */
         public static void throwCannotReopenTask(ReopenTask cmd) throws CannotReopenTask {
             final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
             final ReopenTaskFailed reopenTaskFailed =
                     ReopenTaskFailed.newBuilder()
-                                    .setFailureDetails(commandFailed)
+                                    .setRejectionDetails(commandFailed)
                                     .build();
             throw new CannotReopenTask(reopenTaskFailed);
         }
 
         /**
-         * Constructs and throws the {@link CannotFinalizeDraft} failure
+         * Constructs and throws the {@link CannotFinalizeDraft} rejection
          * according to the passed parameters.
          *
-         * @param cmd the {@code FinalizeDraft} command which thrown the failure
-         * @throws CannotFinalizeDraft the failure to throw
+         * @param cmd the {@code FinalizeDraft} command which thrown the rejection
+         * @throws CannotFinalizeDraft the rejection to throw
          */
         public static void throwCannotFinalizeDraft(FinalizeDraft cmd) throws CannotFinalizeDraft {
             final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
             final FinalizeDraftFailed finalizeDraftFailed =
                     FinalizeDraftFailed.newBuilder()
-                                       .setFailureDetails(commandFailed)
+                                       .setRejectionDetails(commandFailed)
                                        .build();
             throw new CannotFinalizeDraft(finalizeDraftFailed);
         }
 
         /**
-         * Constructs and throws the {@link CannotDeleteTask} failure
+         * Constructs and throws the {@link CannotDeleteTask} rejection
          * according to the passed parameters.
          *
-         * @param cmd the {@code DeleteTask} command which thrown the failure
-         * @throws CannotDeleteTask the failure to throw
+         * @param cmd the {@code DeleteTask} command which thrown the rejection
+         * @throws CannotDeleteTask the rejection to throw
          */
         public static void throwCannotDeleteTask(DeleteTask cmd) throws CannotDeleteTask {
             final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
             final DeleteTaskFailed deleteTaskFailed =
                     DeleteTaskFailed.newBuilder()
-                                    .setFailureDetails(commandFailed)
+                                    .setRejectionDetails(commandFailed)
                                     .build();
             throw new CannotDeleteTask(deleteTaskFailed);
         }
 
         /**
-         * Constructs and throws the {@link CannotCompleteTask} failure
+         * Constructs and throws the {@link CannotCompleteTask} rejection
          * according to the passed parameters.
          *
-         * @param cmd the {@code CompleteTask} command which thrown the failure
-         * @throws CannotCompleteTask the failure to throw
+         * @param cmd the {@code CompleteTask} command which thrown the rejection
+         * @throws CannotCompleteTask the rejection to throw
          */
         public static void throwCannotCompleteTask(CompleteTask cmd) throws CannotCompleteTask {
             final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
             final CompleteTaskFailed completeTaskFailed =
                     CompleteTaskFailed.newBuilder()
-                                      .setFailureDetails(commandFailed)
+                                      .setRejectionDetails(commandFailed)
                                       .build();
             throw new CannotCompleteTask(completeTaskFailed);
         }
 
         /**
-         * Constructs and throws the {@link CannotRestoreDeletedTask} failure
+         * Constructs and throws the {@link CannotRestoreDeletedTask} rejection
          * according to the passed parameters.
          *
-         * @param cmd the {@code RestoreDeletedTask} command which thrown the failure
-         * @throws CannotRestoreDeletedTask the {@code CannotRestoreDeletedTask} failure
+         * @param cmd the {@code RestoreDeletedTask} command which thrown the rejection
+         * @throws CannotRestoreDeletedTask the {@code CannotRestoreDeletedTask} rejection
          */
         public static void throwCannotRestoreDeletedTask(RestoreDeletedTask cmd)
                 throws CannotRestoreDeletedTask {
             final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
             final RestoreDeletedTaskFailed restoreDeletedTaskFailed =
                     RestoreDeletedTaskFailed.newBuilder()
-                                            .setFailureDetails(commandFailed)
+                                            .setRejectionDetails(commandFailed)
                                             .build();
             throw new CannotRestoreDeletedTask(restoreDeletedTaskFailed);
         }

--- a/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/rejection/TaskPartRejections.java
+++ b/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/rejection/TaskPartRejections.java
@@ -77,11 +77,11 @@ public class TaskPartRejections {
          */
         public static void throwCannotUpdateTaskDescription(UpdateTaskDescription cmd)
                 throws CannotUpdateTaskDescription {
-            final RejectedTaskCommandDetails commandRejected =
+            final RejectedTaskCommandDetails commandDetails =
                     newRejectedTaskCommandDetails(cmd.getId());
             final DescriptionUpdateRejected descriptionUpdateRejected =
                     DescriptionUpdateRejected.newBuilder()
-                                             .setRejectionDetails(commandRejected)
+                                             .setCommandDetails(commandDetails)
                                              .build();
             throw new CannotUpdateTaskDescription(descriptionUpdateRejected);
         }
@@ -95,11 +95,11 @@ public class TaskPartRejections {
          */
         public static void throwCannotUpdateTaskDueDate(UpdateTaskDueDate cmd)
                 throws CannotUpdateTaskDueDate {
-            final RejectedTaskCommandDetails commandRejected =
+            final RejectedTaskCommandDetails commandDetails =
                     newRejectedTaskCommandDetails(cmd.getId());
             final TaskDueDateUpdateRejected dueDateUpdateRejected =
                     TaskDueDateUpdateRejected.newBuilder()
-                                             .setRejectionDetails(commandRejected)
+                                             .setCommandDetails(commandDetails)
                                              .build();
             throw new CannotUpdateTaskDueDate(dueDateUpdateRejected);
         }
@@ -114,11 +114,11 @@ public class TaskPartRejections {
          */
         public static void throwCannotUpdateTaskDueDate(
                 UpdateTaskDueDate cmd, ValueMismatch mismatch) throws CannotUpdateTaskDueDate {
-            final RejectedTaskCommandDetails commandRejected =
+            final RejectedTaskCommandDetails commandDetails =
                     newRejectedTaskCommandDetails(cmd.getId());
             final TaskDueDateUpdateRejected dueDateUpdateRejected =
                     TaskDueDateUpdateRejected.newBuilder()
-                                             .setRejectionDetails(commandRejected)
+                                             .setCommandDetails(commandDetails)
                                              .setDueDateMismatch(mismatch)
                                              .build();
             throw new CannotUpdateTaskDueDate(dueDateUpdateRejected);
@@ -135,11 +135,11 @@ public class TaskPartRejections {
         public static void throwCannotUpdateDescription(
                 UpdateTaskDescription cmd, ValueMismatch mismatch)
                 throws CannotUpdateTaskDescription {
-            final RejectedTaskCommandDetails commandRejected =
+            final RejectedTaskCommandDetails commandDetails =
                     newRejectedTaskCommandDetails(cmd.getId());
             final DescriptionUpdateRejected descriptionUpdateRejected =
                     DescriptionUpdateRejected.newBuilder()
-                                             .setRejectionDetails(commandRejected)
+                                             .setCommandDetails(commandDetails)
                                              .setDescriptionMismatch(mismatch)
                                              .build();
             throw new CannotUpdateTaskDescription(descriptionUpdateRejected);
@@ -155,11 +155,11 @@ public class TaskPartRejections {
          */
         public static void throwCannotUpdateTaskPriority(
                 UpdateTaskPriority cmd, ValueMismatch mismatch) throws CannotUpdateTaskPriority {
-            final RejectedTaskCommandDetails commandRejected =
+            final RejectedTaskCommandDetails commandDetails =
                     newRejectedTaskCommandDetails(cmd.getId());
             final PriorityUpdateRejected priorityUpdateRejected =
                     PriorityUpdateRejected.newBuilder()
-                                          .setRejectionDetails(commandRejected)
+                                          .setCommandDetails(commandDetails)
                                           .setPriorityMismatch(mismatch)
                                           .build();
             throw new CannotUpdateTaskPriority(priorityUpdateRejected);
@@ -174,11 +174,11 @@ public class TaskPartRejections {
          */
         public static void throwCannotUpdateTaskPriority(UpdateTaskPriority cmd)
                 throws CannotUpdateTaskPriority {
-            final RejectedTaskCommandDetails commandRejected =
+            final RejectedTaskCommandDetails commandDetails =
                     newRejectedTaskCommandDetails(cmd.getId());
             final PriorityUpdateRejected priorityUpdateRejected =
                     PriorityUpdateRejected.newBuilder()
-                                          .setRejectionDetails(commandRejected)
+                                          .setCommandDetails(commandDetails)
                                           .build();
             throw new CannotUpdateTaskPriority(priorityUpdateRejected);
         }
@@ -197,11 +197,11 @@ public class TaskPartRejections {
          * @throws CannotCreateDraft the rejection to throw
          */
         public static void throwCannotCreateDraft(CreateDraft cmd) throws CannotCreateDraft {
-            final RejectedTaskCommandDetails commandRejected =
+            final RejectedTaskCommandDetails commandDetails =
                     newRejectedTaskCommandDetails(cmd.getId());
             final CreateDraftRejected createDraftRejected =
                     CreateDraftRejected.newBuilder()
-                                       .setRejectionDetails(commandRejected)
+                                       .setCommandDetails(commandDetails)
                                        .build();
             throw new CannotCreateDraft(createDraftRejected);
         }
@@ -220,11 +220,11 @@ public class TaskPartRejections {
          * @throws CannotReopenTask the rejection to throw
          */
         public static void throwCannotReopenTask(ReopenTask cmd) throws CannotReopenTask {
-            final RejectedTaskCommandDetails commandRejected =
+            final RejectedTaskCommandDetails commandDetails =
                     newRejectedTaskCommandDetails(cmd.getId());
             final ReopenTaskRejected reopenTaskRejected =
                     ReopenTaskRejected.newBuilder()
-                                      .setRejectionDetails(commandRejected)
+                                      .setCommandDetails(commandDetails)
                                       .build();
             throw new CannotReopenTask(reopenTaskRejected);
         }
@@ -237,11 +237,11 @@ public class TaskPartRejections {
          * @throws CannotFinalizeDraft the rejection to throw
          */
         public static void throwCannotFinalizeDraft(FinalizeDraft cmd) throws CannotFinalizeDraft {
-            final RejectedTaskCommandDetails commandRejected =
+            final RejectedTaskCommandDetails commandDetails =
                     newRejectedTaskCommandDetails(cmd.getId());
             final FinalizeDraftRejected finalizeDraftRejected =
                     FinalizeDraftRejected.newBuilder()
-                                         .setRejectionDetails(commandRejected)
+                                         .setCommandDetails(commandDetails)
                                          .build();
             throw new CannotFinalizeDraft(finalizeDraftRejected);
         }
@@ -254,11 +254,11 @@ public class TaskPartRejections {
          * @throws CannotDeleteTask the rejection to throw
          */
         public static void throwCannotDeleteTask(DeleteTask cmd) throws CannotDeleteTask {
-            final RejectedTaskCommandDetails commandRejected =
+            final RejectedTaskCommandDetails commandDetails =
                     newRejectedTaskCommandDetails(cmd.getId());
             final DeleteTaskRejected deleteTaskRejected =
                     DeleteTaskRejected.newBuilder()
-                                      .setRejectionDetails(commandRejected)
+                                      .setCommandDetails(commandDetails)
                                       .build();
             throw new CannotDeleteTask(deleteTaskRejected);
         }
@@ -271,11 +271,11 @@ public class TaskPartRejections {
          * @throws CannotCompleteTask the rejection to throw
          */
         public static void throwCannotCompleteTask(CompleteTask cmd) throws CannotCompleteTask {
-            final RejectedTaskCommandDetails commandRejected =
+            final RejectedTaskCommandDetails commandDetails =
                     newRejectedTaskCommandDetails(cmd.getId());
             final CompleteTaskRejected completeTaskRejected =
                     CompleteTaskRejected.newBuilder()
-                                        .setRejectionDetails(commandRejected)
+                                        .setCommandDetails(commandDetails)
                                         .build();
             throw new CannotCompleteTask(completeTaskRejected);
         }
@@ -289,11 +289,11 @@ public class TaskPartRejections {
          */
         public static void throwCannotRestoreDeletedTask(RestoreDeletedTask cmd)
                 throws CannotRestoreDeletedTask {
-            final RejectedTaskCommandDetails commandRejected =
+            final RejectedTaskCommandDetails commandDetails =
                     newRejectedTaskCommandDetails(cmd.getId());
             final RestoreDeletedTaskRejected restoreDeletedTaskRejected =
                     RestoreDeletedTaskRejected.newBuilder()
-                                              .setRejectionDetails(commandRejected)
+                                              .setCommandDetails(commandDetails)
                                               .build();
             throw new CannotRestoreDeletedTask(restoreDeletedTaskRejected);
         }

--- a/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/rejection/TaskPartRejections.java
+++ b/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/rejection/TaskPartRejections.java
@@ -21,16 +21,16 @@
 package io.spine.examples.todolist.c.aggregate.rejection;
 
 import io.spine.change.ValueMismatch;
-import io.spine.examples.todolist.CompleteTaskFailed;
-import io.spine.examples.todolist.CreateDraftFailed;
-import io.spine.examples.todolist.DeleteTaskFailed;
-import io.spine.examples.todolist.DescriptionUpdateFailed;
-import io.spine.examples.todolist.FailedTaskCommandDetails;
-import io.spine.examples.todolist.FinalizeDraftFailed;
-import io.spine.examples.todolist.PriorityUpdateFailed;
-import io.spine.examples.todolist.ReopenTaskFailed;
-import io.spine.examples.todolist.RestoreDeletedTaskFailed;
-import io.spine.examples.todolist.TaskDueDateUpdateFailed;
+import io.spine.examples.todolist.CompleteTaskRejected;
+import io.spine.examples.todolist.CreateDraftRejected;
+import io.spine.examples.todolist.DeleteTaskRejected;
+import io.spine.examples.todolist.DescriptionUpdateRejected;
+import io.spine.examples.todolist.FinalizeDraftRejected;
+import io.spine.examples.todolist.PriorityUpdateRejected;
+import io.spine.examples.todolist.RejectedTaskCommandDetails;
+import io.spine.examples.todolist.ReopenTaskRejected;
+import io.spine.examples.todolist.RestoreDeletedTaskRejected;
+import io.spine.examples.todolist.TaskDueDateUpdateRejected;
 import io.spine.examples.todolist.TaskId;
 import io.spine.examples.todolist.c.aggregate.TaskPart;
 import io.spine.examples.todolist.c.commands.CompleteTask;
@@ -77,12 +77,13 @@ public class TaskPartRejections {
          */
         public static void throwCannotUpdateTaskDescription(UpdateTaskDescription cmd)
                 throws CannotUpdateTaskDescription {
-            final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
-            final DescriptionUpdateFailed descriptionUpdateFailed =
-                    DescriptionUpdateFailed.newBuilder()
-                                           .setRejectionDetails(commandFailed)
-                                           .build();
-            throw new CannotUpdateTaskDescription(descriptionUpdateFailed);
+            final RejectedTaskCommandDetails commandRejected =
+                    newRejectedTaskCommandDetails(cmd.getId());
+            final DescriptionUpdateRejected descriptionUpdateRejected =
+                    DescriptionUpdateRejected.newBuilder()
+                                             .setRejectionDetails(commandRejected)
+                                             .build();
+            throw new CannotUpdateTaskDescription(descriptionUpdateRejected);
         }
 
         /**
@@ -94,12 +95,13 @@ public class TaskPartRejections {
          */
         public static void throwCannotUpdateTaskDueDate(UpdateTaskDueDate cmd)
                 throws CannotUpdateTaskDueDate {
-            final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
-            final TaskDueDateUpdateFailed dueDateUpdateFailed =
-                    TaskDueDateUpdateFailed.newBuilder()
-                                           .setRejectionDetails(commandFailed)
-                                           .build();
-            throw new CannotUpdateTaskDueDate(dueDateUpdateFailed);
+            final RejectedTaskCommandDetails commandRejected =
+                    newRejectedTaskCommandDetails(cmd.getId());
+            final TaskDueDateUpdateRejected dueDateUpdateRejected =
+                    TaskDueDateUpdateRejected.newBuilder()
+                                             .setRejectionDetails(commandRejected)
+                                             .build();
+            throw new CannotUpdateTaskDueDate(dueDateUpdateRejected);
         }
 
         /**
@@ -112,13 +114,14 @@ public class TaskPartRejections {
          */
         public static void throwCannotUpdateTaskDueDate(
                 UpdateTaskDueDate cmd, ValueMismatch mismatch) throws CannotUpdateTaskDueDate {
-            final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
-            final TaskDueDateUpdateFailed dueDateUpdateFailed =
-                    TaskDueDateUpdateFailed.newBuilder()
-                                           .setRejectionDetails(commandFailed)
-                                           .setDueDateMismatch(mismatch)
-                                           .build();
-            throw new CannotUpdateTaskDueDate(dueDateUpdateFailed);
+            final RejectedTaskCommandDetails commandRejected =
+                    newRejectedTaskCommandDetails(cmd.getId());
+            final TaskDueDateUpdateRejected dueDateUpdateRejected =
+                    TaskDueDateUpdateRejected.newBuilder()
+                                             .setRejectionDetails(commandRejected)
+                                             .setDueDateMismatch(mismatch)
+                                             .build();
+            throw new CannotUpdateTaskDueDate(dueDateUpdateRejected);
         }
 
         /**
@@ -132,13 +135,14 @@ public class TaskPartRejections {
         public static void throwCannotUpdateDescription(
                 UpdateTaskDescription cmd, ValueMismatch mismatch)
                 throws CannotUpdateTaskDescription {
-            final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
-            final DescriptionUpdateFailed descriptionUpdateFailed =
-                    DescriptionUpdateFailed.newBuilder()
-                                           .setRejectionDetails(commandFailed)
-                                           .setDescriptionMismatch(mismatch)
-                                           .build();
-            throw new CannotUpdateTaskDescription(descriptionUpdateFailed);
+            final RejectedTaskCommandDetails commandRejected =
+                    newRejectedTaskCommandDetails(cmd.getId());
+            final DescriptionUpdateRejected descriptionUpdateRejected =
+                    DescriptionUpdateRejected.newBuilder()
+                                             .setRejectionDetails(commandRejected)
+                                             .setDescriptionMismatch(mismatch)
+                                             .build();
+            throw new CannotUpdateTaskDescription(descriptionUpdateRejected);
         }
 
         /**
@@ -151,13 +155,14 @@ public class TaskPartRejections {
          */
         public static void throwCannotUpdateTaskPriority(
                 UpdateTaskPriority cmd, ValueMismatch mismatch) throws CannotUpdateTaskPriority {
-            final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
-            final PriorityUpdateFailed priorityUpdateFailed =
-                    PriorityUpdateFailed.newBuilder()
-                                        .setRejectionDetails(commandFailed)
-                                        .setPriorityMismatch(mismatch)
-                                        .build();
-            throw new CannotUpdateTaskPriority(priorityUpdateFailed);
+            final RejectedTaskCommandDetails commandRejected =
+                    newRejectedTaskCommandDetails(cmd.getId());
+            final PriorityUpdateRejected priorityUpdateRejected =
+                    PriorityUpdateRejected.newBuilder()
+                                          .setRejectionDetails(commandRejected)
+                                          .setPriorityMismatch(mismatch)
+                                          .build();
+            throw new CannotUpdateTaskPriority(priorityUpdateRejected);
         }
 
         /**
@@ -169,12 +174,13 @@ public class TaskPartRejections {
          */
         public static void throwCannotUpdateTaskPriority(UpdateTaskPriority cmd)
                 throws CannotUpdateTaskPriority {
-            final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
-            final PriorityUpdateFailed priorityUpdateFailed =
-                    PriorityUpdateFailed.newBuilder()
-                                        .setRejectionDetails(commandFailed)
-                                        .build();
-            throw new CannotUpdateTaskPriority(priorityUpdateFailed);
+            final RejectedTaskCommandDetails commandRejected =
+                    newRejectedTaskCommandDetails(cmd.getId());
+            final PriorityUpdateRejected priorityUpdateRejected =
+                    PriorityUpdateRejected.newBuilder()
+                                          .setRejectionDetails(commandRejected)
+                                          .build();
+            throw new CannotUpdateTaskPriority(priorityUpdateRejected);
         }
     }
 
@@ -191,12 +197,13 @@ public class TaskPartRejections {
          * @throws CannotCreateDraft the rejection to throw
          */
         public static void throwCannotCreateDraft(CreateDraft cmd) throws CannotCreateDraft {
-            final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
-            final CreateDraftFailed createDraftFailed =
-                    CreateDraftFailed.newBuilder()
-                                     .setRejectionDetails(commandFailed)
-                                     .build();
-            throw new CannotCreateDraft(createDraftFailed);
+            final RejectedTaskCommandDetails commandRejected =
+                    newRejectedTaskCommandDetails(cmd.getId());
+            final CreateDraftRejected createDraftRejected =
+                    CreateDraftRejected.newBuilder()
+                                       .setRejectionDetails(commandRejected)
+                                       .build();
+            throw new CannotCreateDraft(createDraftRejected);
         }
     }
 
@@ -213,12 +220,13 @@ public class TaskPartRejections {
          * @throws CannotReopenTask the rejection to throw
          */
         public static void throwCannotReopenTask(ReopenTask cmd) throws CannotReopenTask {
-            final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
-            final ReopenTaskFailed reopenTaskFailed =
-                    ReopenTaskFailed.newBuilder()
-                                    .setRejectionDetails(commandFailed)
-                                    .build();
-            throw new CannotReopenTask(reopenTaskFailed);
+            final RejectedTaskCommandDetails commandRejected =
+                    newRejectedTaskCommandDetails(cmd.getId());
+            final ReopenTaskRejected reopenTaskRejected =
+                    ReopenTaskRejected.newBuilder()
+                                      .setRejectionDetails(commandRejected)
+                                      .build();
+            throw new CannotReopenTask(reopenTaskRejected);
         }
 
         /**
@@ -229,12 +237,13 @@ public class TaskPartRejections {
          * @throws CannotFinalizeDraft the rejection to throw
          */
         public static void throwCannotFinalizeDraft(FinalizeDraft cmd) throws CannotFinalizeDraft {
-            final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
-            final FinalizeDraftFailed finalizeDraftFailed =
-                    FinalizeDraftFailed.newBuilder()
-                                       .setRejectionDetails(commandFailed)
-                                       .build();
-            throw new CannotFinalizeDraft(finalizeDraftFailed);
+            final RejectedTaskCommandDetails commandRejected =
+                    newRejectedTaskCommandDetails(cmd.getId());
+            final FinalizeDraftRejected finalizeDraftRejected =
+                    FinalizeDraftRejected.newBuilder()
+                                         .setRejectionDetails(commandRejected)
+                                         .build();
+            throw new CannotFinalizeDraft(finalizeDraftRejected);
         }
 
         /**
@@ -245,12 +254,13 @@ public class TaskPartRejections {
          * @throws CannotDeleteTask the rejection to throw
          */
         public static void throwCannotDeleteTask(DeleteTask cmd) throws CannotDeleteTask {
-            final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
-            final DeleteTaskFailed deleteTaskFailed =
-                    DeleteTaskFailed.newBuilder()
-                                    .setRejectionDetails(commandFailed)
-                                    .build();
-            throw new CannotDeleteTask(deleteTaskFailed);
+            final RejectedTaskCommandDetails commandRejected =
+                    newRejectedTaskCommandDetails(cmd.getId());
+            final DeleteTaskRejected deleteTaskRejected =
+                    DeleteTaskRejected.newBuilder()
+                                      .setRejectionDetails(commandRejected)
+                                      .build();
+            throw new CannotDeleteTask(deleteTaskRejected);
         }
 
         /**
@@ -261,12 +271,13 @@ public class TaskPartRejections {
          * @throws CannotCompleteTask the rejection to throw
          */
         public static void throwCannotCompleteTask(CompleteTask cmd) throws CannotCompleteTask {
-            final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
-            final CompleteTaskFailed completeTaskFailed =
-                    CompleteTaskFailed.newBuilder()
-                                      .setRejectionDetails(commandFailed)
-                                      .build();
-            throw new CannotCompleteTask(completeTaskFailed);
+            final RejectedTaskCommandDetails commandRejected =
+                    newRejectedTaskCommandDetails(cmd.getId());
+            final CompleteTaskRejected completeTaskRejected =
+                    CompleteTaskRejected.newBuilder()
+                                        .setRejectionDetails(commandRejected)
+                                        .build();
+            throw new CannotCompleteTask(completeTaskRejected);
         }
 
         /**
@@ -278,18 +289,19 @@ public class TaskPartRejections {
          */
         public static void throwCannotRestoreDeletedTask(RestoreDeletedTask cmd)
                 throws CannotRestoreDeletedTask {
-            final FailedTaskCommandDetails commandFailed = newFailedTaskCommandDetails(cmd.getId());
-            final RestoreDeletedTaskFailed restoreDeletedTaskFailed =
-                    RestoreDeletedTaskFailed.newBuilder()
-                                            .setRejectionDetails(commandFailed)
-                                            .build();
-            throw new CannotRestoreDeletedTask(restoreDeletedTaskFailed);
+            final RejectedTaskCommandDetails commandRejected =
+                    newRejectedTaskCommandDetails(cmd.getId());
+            final RestoreDeletedTaskRejected restoreDeletedTaskRejected =
+                    RestoreDeletedTaskRejected.newBuilder()
+                                              .setRejectionDetails(commandRejected)
+                                              .build();
+            throw new CannotRestoreDeletedTask(restoreDeletedTaskRejected);
         }
     }
 
-    private static FailedTaskCommandDetails newFailedTaskCommandDetails(TaskId taskId) {
-        return FailedTaskCommandDetails.newBuilder()
-                                       .setTaskId(taskId)
-                                       .build();
+    private static RejectedTaskCommandDetails newRejectedTaskCommandDetails(TaskId taskId) {
+        return RejectedTaskCommandDetails.newBuilder()
+                                         .setTaskId(taskId)
+                                         .build();
     }
 }

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/LabelAggregateTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/LabelAggregateTest.java
@@ -26,7 +26,7 @@ import io.spine.core.Command;
 import io.spine.core.CommandEnvelope;
 import io.spine.examples.todolist.LabelColor;
 import io.spine.examples.todolist.LabelDetails;
-import io.spine.examples.todolist.LabelDetailsUpdateFailed;
+import io.spine.examples.todolist.LabelDetailsUpdateRejected;
 import io.spine.examples.todolist.LabelId;
 import io.spine.examples.todolist.TaskLabel;
 import io.spine.examples.todolist.c.commands.CreateBasicLabel;
@@ -179,13 +179,13 @@ class LabelAggregateTest {
                                  () -> aggregate.handle(commandMessage().get()));
             final Rejections.CannotUpdateLabelDetails cannotUpdateLabelDetails =
                     rejection.getMessageThrown();
-            final LabelDetailsUpdateFailed labelDetailsUpdateFailed =
-                    cannotUpdateLabelDetails.getUpdateFailed();
-            final LabelId actualLabelId = labelDetailsUpdateFailed.getRejectionDetails()
-                                                                  .getLabelId();
+            final LabelDetailsUpdateRejected detailsUpdateRejected =
+                    cannotUpdateLabelDetails.getUpdateRejected();
+            final LabelId actualLabelId = detailsUpdateRejected.getRejectionDetails()
+                                                               .getLabelId();
             assertEquals(getLabelId(), actualLabelId);
 
-            final ValueMismatch mismatch = labelDetailsUpdateFailed.getLabelDetailsMismatch();
+            final ValueMismatch mismatch = detailsUpdateRejected.getLabelDetailsMismatch();
             assertEquals(pack(expectedLabelDetails), mismatch.getExpected());
             assertEquals(pack(newLabelDetails), mismatch.getNewValue());
 
@@ -197,7 +197,7 @@ class LabelAggregateTest {
         }
     }
 
-    private static abstract class LabelAggregateCommandTest<C extends Message>
+    private abstract static class LabelAggregateCommandTest<C extends Message>
             extends AggregateCommandTest<C, LabelAggregate> {
 
         private LabelId labelId;

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/LabelAggregateTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/LabelAggregateTest.java
@@ -179,13 +179,13 @@ class LabelAggregateTest {
                                  () -> aggregate.handle(commandMessage().get()));
             final Rejections.CannotUpdateLabelDetails cannotUpdateLabelDetails =
                     rejection.getMessageThrown();
-            final LabelDetailsUpdateRejected detailsUpdateRejected =
-                    cannotUpdateLabelDetails.getUpdateRejected();
-            final LabelId actualLabelId = detailsUpdateRejected.getRejectionDetails()
-                                                               .getLabelId();
+            final LabelDetailsUpdateRejected rejectionDetails =
+                    cannotUpdateLabelDetails.getRejectionDetails();
+            final LabelId actualLabelId = rejectionDetails.getCommandDetails()
+                                                          .getLabelId();
             assertEquals(getLabelId(), actualLabelId);
 
-            final ValueMismatch mismatch = detailsUpdateRejected.getLabelDetailsMismatch();
+            final ValueMismatch mismatch = rejectionDetails.getLabelDetailsMismatch();
             assertEquals(pack(expectedLabelDetails), mismatch.getExpected());
             assertEquals(pack(newLabelDetails), mismatch.getNewValue());
 

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/LabelAggregateTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/LabelAggregateTest.java
@@ -33,8 +33,8 @@ import io.spine.examples.todolist.c.commands.CreateBasicLabel;
 import io.spine.examples.todolist.c.commands.UpdateLabelDetails;
 import io.spine.examples.todolist.c.events.LabelCreated;
 import io.spine.examples.todolist.c.events.LabelDetailsUpdated;
-import io.spine.examples.todolist.c.failures.CannotUpdateLabelDetails;
-import io.spine.examples.todolist.c.failures.Rejections;
+import io.spine.examples.todolist.c.rejection.CannotUpdateLabelDetails;
+import io.spine.examples.todolist.c.rejection.Rejections;
 import io.spine.server.aggregate.AggregateCommandTest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -160,7 +160,7 @@ class LabelAggregateTest {
         }
 
         @Test
-        @DisplayName("produce CannotUpdateLabelDetails failure " +
+        @DisplayName("produce CannotUpdateLabelDetails rejection " +
                 "when the label details does not match expected")
         void cannotUpdateLabelDetails() {
             final LabelDetails expectedLabelDetails = LabelDetails.newBuilder()
@@ -174,14 +174,14 @@ class LabelAggregateTest {
             final UpdateLabelDetails updateLabelDetails =
                     updateLabelDetailsInstance(getLabelId(), expectedLabelDetails, newLabelDetails);
             createCommand(updateLabelDetails);
-            final CannotUpdateLabelDetails failure =
+            final CannotUpdateLabelDetails rejection =
                     assertThrows(CannotUpdateLabelDetails.class,
                                  () -> aggregate.handle(commandMessage().get()));
             final Rejections.CannotUpdateLabelDetails cannotUpdateLabelDetails =
-                    failure.getMessageThrown();
+                    rejection.getMessageThrown();
             final LabelDetailsUpdateFailed labelDetailsUpdateFailed =
                     cannotUpdateLabelDetails.getUpdateFailed();
-            final LabelId actualLabelId = labelDetailsUpdateFailed.getFailureDetails()
+            final LabelId actualLabelId = labelDetailsUpdateFailed.getRejectionDetails()
                                                                   .getLabelId();
             assertEquals(getLabelId(), actualLabelId);
 

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/TaskLabelsPartTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/TaskLabelsPartTest.java
@@ -35,8 +35,8 @@ import io.spine.examples.todolist.c.commands.DeleteTask;
 import io.spine.examples.todolist.c.commands.RemoveLabelFromTask;
 import io.spine.examples.todolist.c.events.LabelAssignedToTask;
 import io.spine.examples.todolist.c.events.LabelRemovedFromTask;
-import io.spine.examples.todolist.c.failures.CannotAssignLabelToTask;
-import io.spine.examples.todolist.c.failures.CannotRemoveLabelFromTask;
+import io.spine.examples.todolist.c.rejection.CannotAssignLabelToTask;
+import io.spine.examples.todolist.c.rejection.CannotRemoveLabelFromTask;
 import io.spine.examples.todolist.context.BoundedContexts;
 import io.spine.grpc.MemoizingObserver;
 import io.spine.grpc.StreamObservers;
@@ -109,7 +109,7 @@ class TaskLabelsPartTest {
         }
 
         @Test
-        @DisplayName("throw CannotAssignLabelToTask failure " +
+        @DisplayName("throw CannotAssignLabelToTask rejection " +
                 "upon an attempt to assign the label to the deleted task")
         void cannotAssignLabelToDeletedTask() {
             createBasicTask();
@@ -120,7 +120,7 @@ class TaskLabelsPartTest {
         }
 
         @Test
-        @DisplayName("throw CannotAssignLabelToTask failure " +
+        @DisplayName("throw CannotAssignLabelToTask rejection " +
                 "upon an attempt to assign the label to the completed task")
         void cannotAssignLabelToCompletedTask() {
             createBasicTask();
@@ -181,7 +181,7 @@ class TaskLabelsPartTest {
         }
 
         @Test
-        @DisplayName("throw CannotRemoveLabelFromTask failure " +
+        @DisplayName("throw CannotRemoveLabelFromTask rejection " +
                 "upon an attempt to remove the not assigned label")
         void cannotRemoveNotExistingLabel() {
             assertThrows(CannotRemoveLabelFromTask.class,
@@ -189,7 +189,7 @@ class TaskLabelsPartTest {
         }
 
         @Test
-        @DisplayName("throw CannotRemoveLabelFromTask failure " +
+        @DisplayName("throw CannotRemoveLabelFromTask rejection " +
                 "upon an attempt to remove the label from the completed task")
         void cannotRemoveLabelFromCompletedTask() {
             createBasicTask();
@@ -201,7 +201,7 @@ class TaskLabelsPartTest {
         }
 
         @Test
-        @DisplayName("throw CannotRemoveLabelFromTask failure " +
+        @DisplayName("throw CannotRemoveLabelFromTask rejection " +
                 "upon an attempt to remove the label from the deleted task")
         void cannotRemoveLabelFromDeletedTask() {
             createBasicTask();

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/CompleteTaskTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/CompleteTaskTest.java
@@ -28,7 +28,7 @@ import io.spine.examples.todolist.c.commands.CreateBasicTask;
 import io.spine.examples.todolist.c.commands.CreateDraft;
 import io.spine.examples.todolist.c.commands.DeleteTask;
 import io.spine.examples.todolist.c.events.TaskCompleted;
-import io.spine.examples.todolist.c.failures.CannotCompleteTask;
+import io.spine.examples.todolist.c.rejection.CannotCompleteTask;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -87,7 +87,7 @@ public class CompleteTaskTest extends TaskCommandTest<CompleteTask> {
     }
 
     @Test
-    @DisplayName("throw CannotCompleteTask failure upon an attempt to complete the deleted task")
+    @DisplayName("throw CannotCompleteTask rejection upon an attempt to complete the deleted task")
     void cannotCompleteDeletedTask() {
         dispatchCreateTaskCmd();
 
@@ -99,7 +99,7 @@ public class CompleteTaskTest extends TaskCommandTest<CompleteTask> {
     }
 
     @Test
-    @DisplayName("throw CannotCompleteTask failure upon " +
+    @DisplayName("throw CannotCompleteTask rejection upon " +
             "an attempt to complete the task in draft state")
     void cannotCompleteDraft() {
         final CreateDraft createDraftCmd = createDraftInstance(taskId);

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/CreateDraftTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/CreateDraftTest.java
@@ -97,8 +97,8 @@ public class CreateDraftTest extends TaskCommandTest<CreateDraft> {
         final Throwable cause = Throwables.getRootCause(t);
         final CannotCreateDraft rejection = (CannotCreateDraft) cause;
         final TaskId actualId = rejection.getMessageThrown()
-                                         .getCreateDraftRejected()
                                          .getRejectionDetails()
+                                         .getCommandDetails()
                                          .getTaskId();
         assertEquals(taskId, actualId);
     }

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/CreateDraftTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/CreateDraftTest.java
@@ -60,7 +60,8 @@ public class CreateDraftTest extends TaskCommandTest<CreateDraft> {
     @DisplayName("produce TaskDraftCreated event")
     void produceEvent() {
         final CreateDraft createDraftCmd = createDraftInstance(taskId);
-        final List<? extends Message> messageList = dispatchCommand(aggregate, envelopeOf(createDraftCmd));
+        final List<? extends Message> messageList = dispatchCommand(aggregate,
+                                                                    envelopeOf(createDraftCmd));
         assertEquals(1, messageList.size());
         assertEquals(TaskDraftCreated.class, messageList.get(0)
                                                         .getClass());
@@ -96,7 +97,7 @@ public class CreateDraftTest extends TaskCommandTest<CreateDraft> {
         final Throwable cause = Throwables.getRootCause(t);
         final CannotCreateDraft rejection = (CannotCreateDraft) cause;
         final TaskId actualId = rejection.getMessageThrown()
-                                         .getCreateDraftFailed()
+                                         .getCreateDraftRejected()
                                          .getRejectionDetails()
                                          .getTaskId();
         assertEquals(taskId, actualId);

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/CreateDraftTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/CreateDraftTest.java
@@ -28,7 +28,7 @@ import io.spine.examples.todolist.c.commands.CreateBasicTask;
 import io.spine.examples.todolist.c.commands.CreateDraft;
 import io.spine.examples.todolist.c.commands.DeleteTask;
 import io.spine.examples.todolist.c.events.TaskDraftCreated;
-import io.spine.examples.todolist.c.failures.CannotCreateDraft;
+import io.spine.examples.todolist.c.rejection.CannotCreateDraft;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -80,7 +80,7 @@ public class CreateDraftTest extends TaskCommandTest<CreateDraft> {
     }
 
     @Test
-    @DisplayName("throw CannotCreateDraft failure upon " +
+    @DisplayName("throw CannotCreateDraft rejection upon " +
             "an attempt to create draft with deleted task ID")
     void notCreateDraft() {
         final CreateBasicTask createTaskCmd = createTaskInstance(taskId, DESCRIPTION);
@@ -91,13 +91,14 @@ public class CreateDraftTest extends TaskCommandTest<CreateDraft> {
 
         final CreateDraft createDraftCmd = createDraftInstance(taskId);
         final Throwable t = assertThrows(Throwable.class,
-                                         () -> dispatchCommand(aggregate, envelopeOf(createDraftCmd)));
+                                         () -> dispatchCommand(aggregate,
+                                                               envelopeOf(createDraftCmd)));
         final Throwable cause = Throwables.getRootCause(t);
-        final CannotCreateDraft failure = (CannotCreateDraft) cause;
-        final TaskId actualId = failure.getMessageThrown()
-                                       .getCreateDraftFailed()
-                                       .getFailureDetails()
-                                       .getTaskId();
+        final CannotCreateDraft rejection = (CannotCreateDraft) cause;
+        final TaskId actualId = rejection.getMessageThrown()
+                                         .getCreateDraftFailed()
+                                         .getRejectionDetails()
+                                         .getTaskId();
         assertEquals(taskId, actualId);
     }
 }

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/DeleteTaskCommand.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/DeleteTaskCommand.java
@@ -27,7 +27,7 @@ import io.spine.examples.todolist.Task;
 import io.spine.examples.todolist.c.commands.CreateBasicTask;
 import io.spine.examples.todolist.c.commands.DeleteTask;
 import io.spine.examples.todolist.c.events.TaskDeleted;
-import io.spine.examples.todolist.c.failures.CannotDeleteTask;
+import io.spine.examples.todolist.c.rejection.CannotDeleteTask;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -70,7 +70,7 @@ public class DeleteTaskCommand extends TaskCommandTest<DeleteTask> {
     }
 
     @Test
-    @DisplayName("throw CannotDeleteTask failure upon an attempt to " +
+    @DisplayName("throw CannotDeleteTask rejection upon an attempt to " +
             "delete the already deleted task")
     void cannotDeleteAlreadyDeletedTask() {
         dispatchCreateTaskCmd();

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/FinalizeDraftTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/FinalizeDraftTest.java
@@ -26,7 +26,7 @@ import io.spine.examples.todolist.c.commands.CreateBasicTask;
 import io.spine.examples.todolist.c.commands.CreateDraft;
 import io.spine.examples.todolist.c.commands.DeleteTask;
 import io.spine.examples.todolist.c.commands.FinalizeDraft;
-import io.spine.examples.todolist.c.failures.CannotFinalizeDraft;
+import io.spine.examples.todolist.c.rejection.CannotFinalizeDraft;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -76,7 +76,7 @@ public class FinalizeDraftTest extends TaskCommandTest<FinalizeDraft> {
     }
 
     @Test
-    @DisplayName("throw CannotFinalizeDraft failure upon an attempt to finalize the deleted task")
+    @DisplayName("throw CannotFinalizeDraft rejection upon an attempt to finalize the deleted task")
     void cannotFinalizeDeletedTask() {
         final CreateBasicTask createTaskCmd = createTaskInstance(taskId, DESCRIPTION);
         dispatchCommand(aggregate, envelopeOf(createTaskCmd));
@@ -91,7 +91,7 @@ public class FinalizeDraftTest extends TaskCommandTest<FinalizeDraft> {
     }
 
     @Test
-    @DisplayName("throw CannotFinalizeDraft failure upon an attempt to finalize " +
+    @DisplayName("throw CannotFinalizeDraft rejection upon an attempt to finalize " +
             "the task which is not a draft")
     void cannotFinalizeNotDraftTask() {
         final FinalizeDraft finalizeDraftCmd = finalizeDraftInstance(taskId);

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/ReopenTaskCommandTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/ReopenTaskCommandTest.java
@@ -27,7 +27,7 @@ import io.spine.examples.todolist.c.commands.CreateBasicTask;
 import io.spine.examples.todolist.c.commands.CreateDraft;
 import io.spine.examples.todolist.c.commands.DeleteTask;
 import io.spine.examples.todolist.c.commands.ReopenTask;
-import io.spine.examples.todolist.c.failures.CannotReopenTask;
+import io.spine.examples.todolist.c.rejection.CannotReopenTask;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -59,7 +59,7 @@ public class ReopenTaskCommandTest extends TaskCommandTest<ReopenTask> {
     }
 
     @Test
-    @DisplayName("throw CannotReopenTask failure upon an attempt to reopen not completed task")
+    @DisplayName("throw CannotReopenTask rejection upon an attempt to reopen not completed task")
     void cannotReopenNotCompletedTask() {
         dispatchCreateTaskCmd();
 

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/RestoreDeletedTaskTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/RestoreDeletedTaskTest.java
@@ -36,7 +36,7 @@ import io.spine.examples.todolist.c.commands.CreateDraft;
 import io.spine.examples.todolist.c.commands.DeleteTask;
 import io.spine.examples.todolist.c.commands.RestoreDeletedTask;
 import io.spine.examples.todolist.c.events.LabelledTaskRestored;
-import io.spine.examples.todolist.c.failures.CannotRestoreDeletedTask;
+import io.spine.examples.todolist.c.rejection.CannotRestoreDeletedTask;
 import io.spine.examples.todolist.context.BoundedContexts;
 import io.spine.grpc.MemoizingObserver;
 import io.spine.grpc.StreamObservers;
@@ -170,7 +170,7 @@ public class RestoreDeletedTaskTest extends TaskCommandTest<RestoreDeletedTask> 
     }
 
     @Test
-    @DisplayName("throw CannotRestoreDeletedTask failure upon an attempt to " +
+    @DisplayName("throw CannotRestoreDeletedTask rejection upon an attempt to " +
             "restore the completed task")
     void cannotRestoreCompletedTask() {
         createBasicTask();

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/UpdateTaskDescriptionTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/UpdateTaskDescriptionTest.java
@@ -157,16 +157,16 @@ public class UpdateTaskDescriptionTest extends TaskCommandTest<UpdateTaskDescrip
         @SuppressWarnings("ConstantConditions") // Instance type checked before.
         final Rejections.CannotUpdateTaskDescription rejection =
                 ((CannotUpdateTaskDescription) cause).getMessageThrown();
-        final DescriptionUpdateRejected descriptionUpdateRejected = rejection.getUpdateRejected();
-        final TaskId actualTaskId = descriptionUpdateRejected.getRejectionDetails()
-                                                             .getTaskId();
+        final DescriptionUpdateRejected rejectionDetails = rejection.getRejectionDetails();
+        final TaskId actualTaskId = rejectionDetails.getCommandDetails()
+                                                    .getTaskId();
         assertEquals(taskId, actualTaskId);
 
         final StringValue expectedStringValue = toMessage(expectedValue);
         final StringValue actualStringValue = toMessage(actualValue);
         final StringValue newStringValue = toMessage(newValue);
 
-        final ValueMismatch mismatch = descriptionUpdateRejected.getDescriptionMismatch();
+        final ValueMismatch mismatch = rejectionDetails.getDescriptionMismatch();
         assertEquals(expectedStringValue, unpack(mismatch.getExpected()));
         assertEquals(actualStringValue, unpack(mismatch.getActual()));
         assertEquals(newStringValue, unpack(mismatch.getNewValue()));

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/UpdateTaskDescriptionTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/UpdateTaskDescriptionTest.java
@@ -32,8 +32,8 @@ import io.spine.examples.todolist.c.commands.CreateBasicTask;
 import io.spine.examples.todolist.c.commands.DeleteTask;
 import io.spine.examples.todolist.c.commands.UpdateTaskDescription;
 import io.spine.examples.todolist.c.events.TaskDescriptionUpdated;
-import io.spine.examples.todolist.c.failures.CannotUpdateTaskDescription;
-import io.spine.examples.todolist.c.failures.Rejections;
+import io.spine.examples.todolist.c.rejection.CannotUpdateTaskDescription;
+import io.spine.examples.todolist.c.rejection.Rejections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -87,7 +87,7 @@ public class UpdateTaskDescriptionTest extends TaskCommandTest<UpdateTaskDescrip
     }
 
     @Test
-    @DisplayName("throw CannotUpdateTaskDescription failure " +
+    @DisplayName("throw CannotUpdateTaskDescription rejection " +
             "upon an attempt to update the description of the deleted task")
     void cannotUpdateDeletedTaskDescription() {
         dispatchCreateTaskCmd();
@@ -104,7 +104,7 @@ public class UpdateTaskDescriptionTest extends TaskCommandTest<UpdateTaskDescrip
     }
 
     @Test
-    @DisplayName("throw CannotUpdateTaskDescription failure " +
+    @DisplayName("throw CannotUpdateTaskDescription rejection " +
             "upon an attempt to update the description of the completed task")
     void cannotUpdateCompletedTaskDescription() {
         dispatchCreateTaskCmd();
@@ -137,8 +137,8 @@ public class UpdateTaskDescriptionTest extends TaskCommandTest<UpdateTaskDescrip
     }
 
     @Test
-    @DisplayName("produce CannotUpdateTaskDescription failure")
-    void produceFailure() {
+    @DisplayName("produce CannotUpdateTaskDescription rejection")
+    void produceRejection() {
         final CreateBasicTask createBasicTask = createTaskInstance(taskId, DESCRIPTION);
         dispatchCommand(aggregate, envelopeOf(createBasicTask));
 
@@ -155,10 +155,10 @@ public class UpdateTaskDescriptionTest extends TaskCommandTest<UpdateTaskDescrip
         assertThat(cause, instanceOf(CannotUpdateTaskDescription.class));
 
         @SuppressWarnings("ConstantConditions") // Instance type checked before.
-        final Rejections.CannotUpdateTaskDescription failure =
+        final Rejections.CannotUpdateTaskDescription rejection =
                 ((CannotUpdateTaskDescription) cause).getMessageThrown();
-        final DescriptionUpdateFailed descriptionUpdateFailed = failure.getUpdateFailed();
-        final TaskId actualTaskId = descriptionUpdateFailed.getFailureDetails()
+        final DescriptionUpdateFailed descriptionUpdateFailed = rejection.getUpdateFailed();
+        final TaskId actualTaskId = descriptionUpdateFailed.getRejectionDetails()
                                                            .getTaskId();
         assertEquals(taskId, actualTaskId);
 

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/UpdateTaskDescriptionTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/UpdateTaskDescriptionTest.java
@@ -24,7 +24,7 @@ import com.google.common.base.Throwables;
 import com.google.protobuf.Message;
 import com.google.protobuf.StringValue;
 import io.spine.change.ValueMismatch;
-import io.spine.examples.todolist.DescriptionUpdateFailed;
+import io.spine.examples.todolist.DescriptionUpdateRejected;
 import io.spine.examples.todolist.Task;
 import io.spine.examples.todolist.TaskId;
 import io.spine.examples.todolist.c.commands.CompleteTask;
@@ -157,16 +157,16 @@ public class UpdateTaskDescriptionTest extends TaskCommandTest<UpdateTaskDescrip
         @SuppressWarnings("ConstantConditions") // Instance type checked before.
         final Rejections.CannotUpdateTaskDescription rejection =
                 ((CannotUpdateTaskDescription) cause).getMessageThrown();
-        final DescriptionUpdateFailed descriptionUpdateFailed = rejection.getUpdateFailed();
-        final TaskId actualTaskId = descriptionUpdateFailed.getRejectionDetails()
-                                                           .getTaskId();
+        final DescriptionUpdateRejected descriptionUpdateRejected = rejection.getUpdateRejected();
+        final TaskId actualTaskId = descriptionUpdateRejected.getRejectionDetails()
+                                                             .getTaskId();
         assertEquals(taskId, actualTaskId);
 
         final StringValue expectedStringValue = toMessage(expectedValue);
         final StringValue actualStringValue = toMessage(actualValue);
         final StringValue newStringValue = toMessage(newValue);
 
-        final ValueMismatch mismatch = descriptionUpdateFailed.getDescriptionMismatch();
+        final ValueMismatch mismatch = descriptionUpdateRejected.getDescriptionMismatch();
         assertEquals(expectedStringValue, unpack(mismatch.getExpected()));
         assertEquals(actualStringValue, unpack(mismatch.getActual()));
         assertEquals(newStringValue, unpack(mismatch.getNewValue()));

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/UpdateTaskDueDateTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/UpdateTaskDueDateTest.java
@@ -142,12 +142,12 @@ public class UpdateTaskDueDateTest extends TaskCommandTest<UpdateTaskDueDate> {
         final Rejections.CannotUpdateTaskDueDate cannotUpdateTaskDueDate =
                 ((CannotUpdateTaskDueDate) cause).getMessageThrown();
 
-        final TaskDueDateUpdateRejected dueDateUpdateRejected = cannotUpdateTaskDueDate.getUpdateRejected();
-        final TaskId actualTaskId = dueDateUpdateRejected.getRejectionDetails()
-                                                         .getTaskId();
+        final TaskDueDateUpdateRejected details = cannotUpdateTaskDueDate.getRejectionDetails();
+        final TaskId actualTaskId = details.getCommandDetails()
+                                           .getTaskId();
         assertEquals(taskId, actualTaskId);
 
-        final ValueMismatch mismatch = dueDateUpdateRejected.getDueDateMismatch();
+        final ValueMismatch mismatch = details.getDueDateMismatch();
 
         assertEquals(newDueDate, unpack(mismatch.getNewValue()));
         assertEquals(expectedDueDate, unpack(mismatch.getExpected()));

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/UpdateTaskDueDateTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/UpdateTaskDueDateTest.java
@@ -25,7 +25,7 @@ import com.google.protobuf.Message;
 import com.google.protobuf.Timestamp;
 import io.spine.change.ValueMismatch;
 import io.spine.examples.todolist.Task;
-import io.spine.examples.todolist.TaskDueDateUpdateFailed;
+import io.spine.examples.todolist.TaskDueDateUpdateRejected;
 import io.spine.examples.todolist.TaskId;
 import io.spine.examples.todolist.c.commands.CompleteTask;
 import io.spine.examples.todolist.c.commands.CreateBasicTask;
@@ -76,7 +76,8 @@ public class UpdateTaskDueDateTest extends TaskCommandTest<UpdateTaskDueDate> {
 
         final UpdateTaskDueDate updateTaskDueDateCmd = updateTaskDueDateInstance(taskId);
         final Throwable t = assertThrows(Throwable.class,
-                                         () -> dispatchCommand(aggregate, envelopeOf(updateTaskDueDateCmd)));
+                                         () -> dispatchCommand(aggregate,
+                                                               envelopeOf(updateTaskDueDateCmd)));
         assertThat(Throwables.getRootCause(t), instanceOf(CannotUpdateTaskDueDate.class));
     }
 
@@ -89,7 +90,8 @@ public class UpdateTaskDueDateTest extends TaskCommandTest<UpdateTaskDueDate> {
 
         final UpdateTaskDueDate updateTaskDueDateCmd = updateTaskDueDateInstance(taskId);
         final Throwable t = assertThrows(Throwable.class,
-                                         () -> dispatchCommand(aggregate, envelopeOf(updateTaskDueDateCmd)));
+                                         () -> dispatchCommand(aggregate,
+                                                               envelopeOf(updateTaskDueDateCmd)));
         assertThat(Throwables.getRootCause(t), instanceOf(CannotUpdateTaskDueDate.class));
     }
 
@@ -97,8 +99,8 @@ public class UpdateTaskDueDateTest extends TaskCommandTest<UpdateTaskDueDate> {
     @DisplayName("produce TaskDueDateUpdated event")
     void produceEvent() {
         final UpdateTaskDueDate updateTaskDueDateCmd = updateTaskDueDateInstance(taskId);
-        final List<? extends Message> messageList = dispatchCommand(aggregate,
-                                                             envelopeOf(updateTaskDueDateCmd));
+        final List<? extends Message> messageList =
+                dispatchCommand(aggregate, envelopeOf(updateTaskDueDateCmd));
         assertEquals(1, messageList.size());
         assertEquals(TaskDueDateUpdated.class, messageList.get(0)
                                                           .getClass());
@@ -132,19 +134,20 @@ public class UpdateTaskDueDateTest extends TaskCommandTest<UpdateTaskDueDate> {
         final UpdateTaskDueDate updateTaskDueDate =
                 updateTaskDueDateInstance(taskId, expectedDueDate, newDueDate);
         final Throwable t = assertThrows(Throwable.class,
-                                         () -> dispatchCommand(aggregate, envelopeOf(updateTaskDueDate)));
+                                         () -> dispatchCommand(aggregate,
+                                                               envelopeOf(updateTaskDueDate)));
         final Throwable cause = Throwables.getRootCause(t);
         assertThat(cause, instanceOf(CannotUpdateTaskDueDate.class));
 
         final Rejections.CannotUpdateTaskDueDate cannotUpdateTaskDueDate =
                 ((CannotUpdateTaskDueDate) cause).getMessageThrown();
 
-        final TaskDueDateUpdateFailed dueDateUpdateFailed = cannotUpdateTaskDueDate.getUpdateFailed();
-        final TaskId actualTaskId = dueDateUpdateFailed.getRejectionDetails()
-                                                       .getTaskId();
+        final TaskDueDateUpdateRejected dueDateUpdateRejected = cannotUpdateTaskDueDate.getUpdateRejected();
+        final TaskId actualTaskId = dueDateUpdateRejected.getRejectionDetails()
+                                                         .getTaskId();
         assertEquals(taskId, actualTaskId);
 
-        final ValueMismatch mismatch = dueDateUpdateFailed.getDueDateMismatch();
+        final ValueMismatch mismatch = dueDateUpdateRejected.getDueDateMismatch();
 
         assertEquals(newDueDate, unpack(mismatch.getNewValue()));
         assertEquals(expectedDueDate, unpack(mismatch.getExpected()));

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/UpdateTaskDueDateTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/UpdateTaskDueDateTest.java
@@ -32,8 +32,8 @@ import io.spine.examples.todolist.c.commands.CreateBasicTask;
 import io.spine.examples.todolist.c.commands.DeleteTask;
 import io.spine.examples.todolist.c.commands.UpdateTaskDueDate;
 import io.spine.examples.todolist.c.events.TaskDueDateUpdated;
-import io.spine.examples.todolist.c.failures.CannotUpdateTaskDueDate;
-import io.spine.examples.todolist.c.failures.Rejections;
+import io.spine.examples.todolist.c.rejection.CannotUpdateTaskDueDate;
+import io.spine.examples.todolist.c.rejection.Rejections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -68,7 +68,7 @@ public class UpdateTaskDueDateTest extends TaskCommandTest<UpdateTaskDueDate> {
     }
 
     @Test
-    @DisplayName("throw CannotUpdateTaskDueDate failure " +
+    @DisplayName("throw CannotUpdateTaskDueDate rejection " +
             "upon an attempt to update the due date of the completed task")
     void cannotUpdateCompletedTaskDueDate() {
         final CompleteTask completeTaskCmd = completeTaskInstance(taskId);
@@ -81,7 +81,7 @@ public class UpdateTaskDueDateTest extends TaskCommandTest<UpdateTaskDueDate> {
     }
 
     @Test
-    @DisplayName("throw CannotUpdateTaskDueDate failure " +
+    @DisplayName("throw CannotUpdateTaskDueDate rejection " +
             "upon an attempt to update the due date of the deleted task")
     void cannotUpdateDeletedTaskDueDate() {
         final DeleteTask deleteTaskCmd = deleteTaskInstance(taskId);
@@ -124,8 +124,8 @@ public class UpdateTaskDueDateTest extends TaskCommandTest<UpdateTaskDueDate> {
     }
 
     @Test
-    @DisplayName("produce CannotUpdateTaskDueDate failure")
-    void produceFailure() {
+    @DisplayName("produce CannotUpdateTaskDueDate rejection")
+    void produceRejection() {
         final Timestamp expectedDueDate = getCurrentTime();
         final Timestamp newDueDate = getCurrentTime();
 
@@ -140,7 +140,7 @@ public class UpdateTaskDueDateTest extends TaskCommandTest<UpdateTaskDueDate> {
                 ((CannotUpdateTaskDueDate) cause).getMessageThrown();
 
         final TaskDueDateUpdateFailed dueDateUpdateFailed = cannotUpdateTaskDueDate.getUpdateFailed();
-        final TaskId actualTaskId = dueDateUpdateFailed.getFailureDetails()
+        final TaskId actualTaskId = dueDateUpdateFailed.getRejectionDetails()
                                                        .getTaskId();
         assertEquals(taskId, actualTaskId);
 

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/UpdateTaskPriorityTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/UpdateTaskPriorityTest.java
@@ -34,8 +34,8 @@ import io.spine.examples.todolist.c.commands.CreateBasicTask;
 import io.spine.examples.todolist.c.commands.DeleteTask;
 import io.spine.examples.todolist.c.commands.UpdateTaskPriority;
 import io.spine.examples.todolist.c.events.TaskPriorityUpdated;
-import io.spine.examples.todolist.c.failures.CannotUpdateTaskPriority;
-import io.spine.examples.todolist.c.failures.Rejections;
+import io.spine.examples.todolist.c.rejection.CannotUpdateTaskPriority;
+import io.spine.examples.todolist.c.rejection.Rejections;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -71,7 +71,7 @@ public class UpdateTaskPriorityTest extends TaskCommandTest<UpdateTaskPriority> 
     }
 
     @Test
-    @DisplayName("throw CannotUpdateTaskPriority failure upon an attempt to " +
+    @DisplayName("throw CannotUpdateTaskPriority rejection upon an attempt to " +
             "update the priority of the deleted task")
     void cannotUpdateDeletedTaskPriority() {
         dispatchCreateTaskCmd();
@@ -87,7 +87,7 @@ public class UpdateTaskPriorityTest extends TaskCommandTest<UpdateTaskPriority> 
     }
 
     @Test
-    @DisplayName("throw CannotUpdateTaskPriority failure " +
+    @DisplayName("throw CannotUpdateTaskPriority rejection " +
             "upon an attempt to update the priority of the completed task")
     void cannotUpdateCompletedTaskPriority() {
         dispatchCreateTaskCmd();
@@ -136,8 +136,8 @@ public class UpdateTaskPriorityTest extends TaskCommandTest<UpdateTaskPriority> 
     }
 
     @Test
-    @DisplayName("produce CannotUpdateTaskPriority failure")
-    void produceFailure() {
+    @DisplayName("produce CannotUpdateTaskPriority rejection")
+    void produceRejection() {
         final UpdateTaskPriority updateTaskPriority = updateTaskPriorityInstance(taskId, LOW, HIGH);
         final Throwable t = assertThrows(Throwable.class,
                                          () -> dispatchCommand(aggregate, envelopeOf(updateTaskPriority)));
@@ -149,7 +149,7 @@ public class UpdateTaskPriorityTest extends TaskCommandTest<UpdateTaskPriority> 
                 ((CannotUpdateTaskPriority) cause).getMessageThrown();
         final PriorityUpdateFailed priorityUpdateFailed =
                 cannotUpdateTaskPriority.getUpdateFailed();
-        final TaskId actualTaskId = priorityUpdateFailed.getFailureDetails()
+        final TaskId actualTaskId = priorityUpdateFailed.getRejectionDetails()
                                                         .getTaskId();
         assertEquals(taskId, actualTaskId);
 

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/UpdateTaskPriorityTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/UpdateTaskPriorityTest.java
@@ -151,14 +151,14 @@ public class UpdateTaskPriorityTest extends TaskCommandTest<UpdateTaskPriority> 
         @SuppressWarnings("ConstantConditions") // Instance type checked before.
         final Rejections.CannotUpdateTaskPriority cannotUpdateTaskPriority =
                 ((CannotUpdateTaskPriority) cause).getMessageThrown();
-        final PriorityUpdateRejected priorityUpdateRejected =
-                cannotUpdateTaskPriority.getUpdateRejected();
-        final TaskId actualTaskId = priorityUpdateRejected.getRejectionDetails()
-                                                          .getTaskId();
+        final PriorityUpdateRejected rejectionDetails =
+                cannotUpdateTaskPriority.getRejectionDetails();
+        final TaskId actualTaskId = rejectionDetails.getCommandDetails()
+                                                    .getTaskId();
         assertEquals(taskId, actualTaskId);
 
         final PriorityChange priorityChange = updateTaskPriority.getPriorityChange();
-        final ValueMismatch mismatch = priorityUpdateRejected.getPriorityMismatch();
+        final ValueMismatch mismatch = rejectionDetails.getPriorityMismatch();
         final TaskPriorityValue expectedValue = priorityValueOf(priorityChange.getPreviousValue());
         final TaskPriorityValue actualValue = priorityValueOf(TP_UNDEFINED);
         final TaskPriorityValue newValue = priorityValueOf(priorityChange.getNewValue());

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/UpdateTaskPriorityTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/definition/UpdateTaskPriorityTest.java
@@ -24,7 +24,7 @@ import com.google.common.base.Throwables;
 import com.google.protobuf.Message;
 import io.spine.change.ValueMismatch;
 import io.spine.examples.todolist.PriorityChange;
-import io.spine.examples.todolist.PriorityUpdateFailed;
+import io.spine.examples.todolist.PriorityUpdateRejected;
 import io.spine.examples.todolist.Task;
 import io.spine.examples.todolist.TaskId;
 import io.spine.examples.todolist.TaskPriority;
@@ -81,7 +81,8 @@ public class UpdateTaskPriorityTest extends TaskCommandTest<UpdateTaskPriority> 
 
         final UpdateTaskPriority updateTaskPriorityCmd = updateTaskPriorityInstance(taskId);
         final Throwable t = assertThrows(Throwable.class,
-                                         () -> dispatchCommand(aggregate, envelopeOf(updateTaskPriorityCmd)));
+                                         () -> dispatchCommand(aggregate,
+                                                               envelopeOf(updateTaskPriorityCmd)));
         assertThat(Throwables.getRootCause(t), instanceOf(CannotUpdateTaskPriority.class));
 
     }
@@ -97,7 +98,8 @@ public class UpdateTaskPriorityTest extends TaskCommandTest<UpdateTaskPriority> 
 
         final UpdateTaskPriority updateTaskPriorityCmd = updateTaskPriorityInstance(taskId);
         final Throwable t = assertThrows(Throwable.class,
-                                         () -> dispatchCommand(aggregate, envelopeOf(updateTaskPriorityCmd)));
+                                         () -> dispatchCommand(aggregate,
+                                                               envelopeOf(updateTaskPriorityCmd)));
         assertThat(Throwables.getRootCause(t), instanceOf(CannotUpdateTaskPriority.class));
     }
 
@@ -108,7 +110,8 @@ public class UpdateTaskPriorityTest extends TaskCommandTest<UpdateTaskPriority> 
 
         final UpdateTaskPriority updateTaskPriorityCmd = updateTaskPriorityInstance(taskId);
         final List<? extends Message> messageList = dispatchCommand(aggregate,
-                                                             envelopeOf(updateTaskPriorityCmd));
+                                                                    envelopeOf(
+                                                                            updateTaskPriorityCmd));
         assertEquals(1, messageList.size());
         assertEquals(TaskPriorityUpdated.class, messageList.get(0)
                                                            .getClass());
@@ -140,21 +143,22 @@ public class UpdateTaskPriorityTest extends TaskCommandTest<UpdateTaskPriority> 
     void produceRejection() {
         final UpdateTaskPriority updateTaskPriority = updateTaskPriorityInstance(taskId, LOW, HIGH);
         final Throwable t = assertThrows(Throwable.class,
-                                         () -> dispatchCommand(aggregate, envelopeOf(updateTaskPriority)));
+                                         () -> dispatchCommand(aggregate,
+                                                               envelopeOf(updateTaskPriority)));
         final Throwable cause = Throwables.getRootCause(t);
         assertThat(cause, instanceOf(CannotUpdateTaskPriority.class));
 
         @SuppressWarnings("ConstantConditions") // Instance type checked before.
         final Rejections.CannotUpdateTaskPriority cannotUpdateTaskPriority =
                 ((CannotUpdateTaskPriority) cause).getMessageThrown();
-        final PriorityUpdateFailed priorityUpdateFailed =
-                cannotUpdateTaskPriority.getUpdateFailed();
-        final TaskId actualTaskId = priorityUpdateFailed.getRejectionDetails()
-                                                        .getTaskId();
+        final PriorityUpdateRejected priorityUpdateRejected =
+                cannotUpdateTaskPriority.getUpdateRejected();
+        final TaskId actualTaskId = priorityUpdateRejected.getRejectionDetails()
+                                                          .getTaskId();
         assertEquals(taskId, actualTaskId);
 
         final PriorityChange priorityChange = updateTaskPriority.getPriorityChange();
-        final ValueMismatch mismatch = priorityUpdateFailed.getPriorityMismatch();
+        final ValueMismatch mismatch = priorityUpdateRejected.getPriorityMismatch();
         final TaskPriorityValue expectedValue = priorityValueOf(priorityChange.getPreviousValue());
         final TaskPriorityValue actualValue = priorityValueOf(TP_UNDEFINED);
         final TaskPriorityValue newValue = priorityValueOf(priorityChange.getNewValue());
@@ -168,7 +172,7 @@ public class UpdateTaskPriorityTest extends TaskCommandTest<UpdateTaskPriority> 
         dispatchCommand(aggregate, envelopeOf(createTaskCmd));
     }
 
-    private TaskPriorityValue priorityValueOf(TaskPriority taskPriority) {
+    private static TaskPriorityValue priorityValueOf(TaskPriority taskPriority) {
         return TaskPriorityValue.newBuilder()
                                 .setPriorityValue(taskPriority)
                                 .build();

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/rejection/LabelAggregateRejectionsTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/rejection/LabelAggregateRejectionsTest.java
@@ -18,38 +18,36 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.examples.todolist.c.aggregate.failures;
+package io.spine.examples.todolist.c.aggregate.rejection;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import io.spine.core.CommandContext;
 import io.spine.change.ValueMismatch;
 import io.spine.examples.todolist.c.commands.UpdateLabelDetails;
-import io.spine.examples.todolist.c.failures.CannotUpdateLabelDetails;
+import io.spine.examples.todolist.c.rejection.CannotUpdateLabelDetails;
 
+import static io.spine.examples.todolist.c.aggregate.rejection.LabelAggregateRejections.throwCannotUpdateLabelDetails;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static io.spine.examples.todolist.c.aggregate.failures.LabelAggregateFailures.throwCannotUpdateLabelDetailsFailure;
 import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
 
 /**
  * @author Illia Shepilov
  */
-@DisplayName("LabelAggregateFailures should")
-class LabelAggregateFailuresTest {
+@DisplayName("LabelAggregateRejections should")
+class LabelAggregateRejectionsTest {
 
     @Test
     @DisplayName("have the private constructor")
     public void havePrivateConstructor() {
-        assertHasPrivateParameterlessCtor(LabelAggregateFailures.class);
+        assertHasPrivateParameterlessCtor(LabelAggregateRejections.class);
     }
 
     @Test
-    @DisplayName("throw CannotUpdateLabelDetails failure")
-    public void throwCannotUpdateLabelDetails() {
+    @DisplayName("throw CannotUpdateLabelDetails rejection")
+    public void throwCannotUpdateLabelDetailsRejection() {
         final UpdateLabelDetails cmd = UpdateLabelDetails.getDefaultInstance();
-        final CommandContext ctx = CommandContext.getDefaultInstance();
         final ValueMismatch valueMismatch = ValueMismatch.getDefaultInstance();
-        assertThrows(CannotUpdateLabelDetails.class, () ->
-                throwCannotUpdateLabelDetailsFailure(cmd, valueMismatch));
+        assertThrows(CannotUpdateLabelDetails.class,
+                     () -> throwCannotUpdateLabelDetails(cmd, valueMismatch));
     }
 }

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/rejection/TaskLabelsPartRejectionsTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/rejection/TaskLabelsPartRejectionsTest.java
@@ -18,19 +18,20 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.examples.todolist.c.aggregate.failures;
+package io.spine.examples.todolist.c.aggregate.rejection;
 
-import io.spine.core.CommandContext;
 import io.spine.examples.todolist.FailedTaskCommandDetails;
 import io.spine.examples.todolist.LabelId;
 import io.spine.examples.todolist.TaskId;
 import io.spine.examples.todolist.c.commands.AssignLabelToTask;
 import io.spine.examples.todolist.c.commands.RemoveLabelFromTask;
-import io.spine.examples.todolist.c.failures.CannotAssignLabelToTask;
-import io.spine.examples.todolist.c.failures.CannotRemoveLabelFromTask;
+import io.spine.examples.todolist.c.rejection.CannotAssignLabelToTask;
+import io.spine.examples.todolist.c.rejection.CannotRemoveLabelFromTask;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import static io.spine.examples.todolist.c.aggregate.rejection.TaskLabelsPartRejections.throwCannotAssignLabelToTask;
+import static io.spine.examples.todolist.c.aggregate.rejection.TaskLabelsPartRejections.throwCannotRemoveLabelFromTask;
 import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -47,43 +48,39 @@ class TaskLabelsPartRejectionsTest {
     @Test
     @DisplayName("have the private constructor")
     void havePrivateConstructor() {
-        assertHasPrivateParameterlessCtor(TaskLabelsPartFailures.class);
+        assertHasPrivateParameterlessCtor(TaskLabelsPartRejections.class);
     }
 
     @Test
-    @DisplayName("throw CannotRemoveLabelFromTask failure")
-    void throwCannotRemoveLabelFromTask() {
+    @DisplayName("throw CannotRemoveLabelFromTask rejection")
+    void throwCannotRemoveLabelFromTaskRejection() {
         final RemoveLabelFromTask cmd = RemoveLabelFromTask.newBuilder()
                                                            .setId(taskId)
                                                            .setLabelId(labelId)
                                                            .build();
-        final CommandContext ctx = CommandContext.getDefaultInstance();
-
-        final CannotRemoveLabelFromTask failure =
+        final CannotRemoveLabelFromTask rejection =
                 assertThrows(CannotRemoveLabelFromTask.class,
-                             () -> TaskLabelsPartFailures.throwCannotRemoveLabelFromTaskFailure(cmd));
-        final TaskId actual = failure.getMessageThrown()
-                                     .getRemoveLabelFailed()
-                                     .getFailureDetails()
-                                     .getTaskId();
+                             () -> throwCannotRemoveLabelFromTask(cmd));
+        final TaskId actual = rejection.getMessageThrown()
+                                       .getRemoveLabelFailed()
+                                       .getRejectionDetails()
+                                       .getTaskId();
         assertEquals(taskId, actual);
     }
 
     @Test
-    @DisplayName("throw CannotAssignLabelToTask failure")
-    void throwCannotAssignLabelToTask() {
+    @DisplayName("throw CannotAssignLabelToTask rejection")
+    void throwCannotAssignLabelToTaskRejection() {
         final AssignLabelToTask cmd = AssignLabelToTask.newBuilder()
                                                        .setLabelId(labelId)
                                                        .setId(taskId)
                                                        .build();
-        final CommandContext ctx = CommandContext.getDefaultInstance();
-
-        final CannotAssignLabelToTask failure =
+        final CannotAssignLabelToTask rejection =
                 assertThrows(CannotAssignLabelToTask.class,
-                             () -> TaskLabelsPartFailures.throwCannotAssignLabelToTaskFailure(cmd));
-        final FailedTaskCommandDetails failedCommand = failure.getMessageThrown()
-                                                              .getAssignLabelFailed()
-                                                              .getFailureDetails();
+                             () -> throwCannotAssignLabelToTask(cmd));
+        final FailedTaskCommandDetails failedCommand = rejection.getMessageThrown()
+                                                                .getAssignLabelFailed()
+                                                                .getRejectionDetails();
         final TaskId actualId = failedCommand.getTaskId();
         assertEquals(taskId, actualId);
     }

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/rejection/TaskLabelsPartRejectionsTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/rejection/TaskLabelsPartRejectionsTest.java
@@ -20,8 +20,8 @@
 
 package io.spine.examples.todolist.c.aggregate.rejection;
 
-import io.spine.examples.todolist.FailedTaskCommandDetails;
 import io.spine.examples.todolist.LabelId;
+import io.spine.examples.todolist.RejectedTaskCommandDetails;
 import io.spine.examples.todolist.TaskId;
 import io.spine.examples.todolist.c.commands.AssignLabelToTask;
 import io.spine.examples.todolist.c.commands.RemoveLabelFromTask;
@@ -62,7 +62,7 @@ class TaskLabelsPartRejectionsTest {
                 assertThrows(CannotRemoveLabelFromTask.class,
                              () -> throwCannotRemoveLabelFromTask(cmd));
         final TaskId actual = rejection.getMessageThrown()
-                                       .getRemoveLabelFailed()
+                                       .getRemoveLabelRejected()
                                        .getRejectionDetails()
                                        .getTaskId();
         assertEquals(taskId, actual);
@@ -78,10 +78,10 @@ class TaskLabelsPartRejectionsTest {
         final CannotAssignLabelToTask rejection =
                 assertThrows(CannotAssignLabelToTask.class,
                              () -> throwCannotAssignLabelToTask(cmd));
-        final FailedTaskCommandDetails failedCommand = rejection.getMessageThrown()
-                                                                .getAssignLabelFailed()
-                                                                .getRejectionDetails();
-        final TaskId actualId = failedCommand.getTaskId();
+        final RejectedTaskCommandDetails rejectedCommand = rejection.getMessageThrown()
+                                                                    .getAssignLabelRejected()
+                                                                    .getRejectionDetails();
+        final TaskId actualId = rejectedCommand.getTaskId();
         assertEquals(taskId, actualId);
     }
 }

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/rejection/TaskLabelsPartRejectionsTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/rejection/TaskLabelsPartRejectionsTest.java
@@ -21,7 +21,6 @@
 package io.spine.examples.todolist.c.aggregate.rejection;
 
 import io.spine.examples.todolist.LabelId;
-import io.spine.examples.todolist.RejectedTaskCommandDetails;
 import io.spine.examples.todolist.TaskId;
 import io.spine.examples.todolist.c.commands.AssignLabelToTask;
 import io.spine.examples.todolist.c.commands.RemoveLabelFromTask;
@@ -61,11 +60,11 @@ class TaskLabelsPartRejectionsTest {
         final CannotRemoveLabelFromTask rejection =
                 assertThrows(CannotRemoveLabelFromTask.class,
                              () -> throwCannotRemoveLabelFromTask(cmd));
-        final TaskId actual = rejection.getMessageThrown()
-                                       .getRemoveLabelRejected()
-                                       .getRejectionDetails()
-                                       .getTaskId();
-        assertEquals(taskId, actual);
+        final TaskId actualId = rejection.getMessageThrown()
+                                         .getRejectionDetails()
+                                         .getCommandDetails()
+                                         .getTaskId();
+        assertEquals(taskId, actualId);
     }
 
     @Test
@@ -78,10 +77,10 @@ class TaskLabelsPartRejectionsTest {
         final CannotAssignLabelToTask rejection =
                 assertThrows(CannotAssignLabelToTask.class,
                              () -> throwCannotAssignLabelToTask(cmd));
-        final RejectedTaskCommandDetails rejectedCommand = rejection.getMessageThrown()
-                                                                    .getAssignLabelRejected()
-                                                                    .getRejectionDetails();
-        final TaskId actualId = rejectedCommand.getTaskId();
+        final TaskId actualId = rejection.getMessageThrown()
+                                         .getRejectionDetails()
+                                         .getCommandDetails()
+                                         .getTaskId();
         assertEquals(taskId, actualId);
     }
 }

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/rejection/TaskPartRejectionsTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/rejection/TaskPartRejectionsTest.java
@@ -85,8 +85,8 @@ class TaskPartRejectionsTest {
             final CannotCreateDraft rejection = assertThrows(CannotCreateDraft.class,
                                                              () -> throwCannotCreateDraft(cmd));
             final TaskId actual = rejection.getMessageThrown()
-                                           .getCreateDraftRejected()
                                            .getRejectionDetails()
+                                           .getCommandDetails()
                                            .getTaskId();
             assertEquals(taskId, actual);
         }
@@ -111,10 +111,10 @@ class TaskPartRejectionsTest {
             final CannotUpdateTaskDueDate rejection =
                     assertThrows(CannotUpdateTaskDueDate.class,
                                  () -> throwCannotUpdateTaskDueDate(cmd));
-            final RejectedTaskCommandDetails rejectedCommand = rejection.getMessageThrown()
-                                                                        .getUpdateRejected()
-                                                                        .getRejectionDetails();
-            final TaskId actualId = rejectedCommand.getTaskId();
+            final RejectedTaskCommandDetails commandDetails = rejection.getMessageThrown()
+                                                                       .getRejectionDetails()
+                                                                       .getCommandDetails();
+            final TaskId actualId = commandDetails.getTaskId();
             assertEquals(taskId, actualId);
         }
 
@@ -127,10 +127,11 @@ class TaskPartRejectionsTest {
             final CannotUpdateTaskDescription rejection =
                     assertThrows(CannotUpdateTaskDescription.class,
                                  () -> throwCannotUpdateTaskDescription(cmd));
-            final RejectedTaskCommandDetails rejectedCommand = rejection.getMessageThrown()
-                                                                        .getUpdateRejected()
-                                                                        .getRejectionDetails();
-            final TaskId actualId = rejectedCommand.getTaskId();
+            final RejectedTaskCommandDetails commandDetails = rejection.getMessageThrown()
+                                                                       .getRejectionDetails()
+                                                                       .getCommandDetails();
+
+            final TaskId actualId = commandDetails.getTaskId();
             assertEquals(taskId, actualId);
         }
     }

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/rejection/TaskPartRejectionsTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/rejection/TaskPartRejectionsTest.java
@@ -20,7 +20,7 @@
 
 package io.spine.examples.todolist.c.aggregate.rejection;
 
-import io.spine.examples.todolist.FailedTaskCommandDetails;
+import io.spine.examples.todolist.RejectedTaskCommandDetails;
 import io.spine.examples.todolist.TaskId;
 import io.spine.examples.todolist.c.aggregate.rejection.TaskPartRejections.ChangeStatusRejections;
 import io.spine.examples.todolist.c.aggregate.rejection.TaskPartRejections.UpdateRejections;
@@ -85,7 +85,7 @@ class TaskPartRejectionsTest {
             final CannotCreateDraft rejection = assertThrows(CannotCreateDraft.class,
                                                              () -> throwCannotCreateDraft(cmd));
             final TaskId actual = rejection.getMessageThrown()
-                                           .getCreateDraftFailed()
+                                           .getCreateDraftRejected()
                                            .getRejectionDetails()
                                            .getTaskId();
             assertEquals(taskId, actual);
@@ -111,10 +111,10 @@ class TaskPartRejectionsTest {
             final CannotUpdateTaskDueDate rejection =
                     assertThrows(CannotUpdateTaskDueDate.class,
                                  () -> throwCannotUpdateTaskDueDate(cmd));
-            final FailedTaskCommandDetails failedCommand = rejection.getMessageThrown()
-                                                                    .getUpdateFailed()
-                                                                    .getRejectionDetails();
-            final TaskId actualId = failedCommand.getTaskId();
+            final RejectedTaskCommandDetails rejectedCommand = rejection.getMessageThrown()
+                                                                        .getUpdateRejected()
+                                                                        .getRejectionDetails();
+            final TaskId actualId = rejectedCommand.getTaskId();
             assertEquals(taskId, actualId);
         }
 
@@ -127,10 +127,10 @@ class TaskPartRejectionsTest {
             final CannotUpdateTaskDescription rejection =
                     assertThrows(CannotUpdateTaskDescription.class,
                                  () -> throwCannotUpdateTaskDescription(cmd));
-            final FailedTaskCommandDetails failedCommand = rejection.getMessageThrown()
-                                                                    .getUpdateFailed()
-                                                                    .getRejectionDetails();
-            final TaskId actualId = failedCommand.getTaskId();
+            final RejectedTaskCommandDetails rejectedCommand = rejection.getMessageThrown()
+                                                                        .getUpdateRejected()
+                                                                        .getRejectionDetails();
+            final TaskId actualId = rejectedCommand.getTaskId();
             assertEquals(taskId, actualId);
         }
     }

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/rejection/TaskPartRejectionsTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/rejection/TaskPartRejectionsTest.java
@@ -18,26 +18,25 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-package io.spine.examples.todolist.c.aggregate.failures;
+package io.spine.examples.todolist.c.aggregate.rejection;
 
 import io.spine.examples.todolist.FailedTaskCommandDetails;
 import io.spine.examples.todolist.TaskId;
-import io.spine.examples.todolist.c.aggregate.failures.TaskPartFailures.ChangeStatusFailures;
-import io.spine.examples.todolist.c.aggregate.failures.TaskPartFailures.TaskCreationFailures;
-import io.spine.examples.todolist.c.aggregate.failures.TaskPartFailures.UpdateFailures;
+import io.spine.examples.todolist.c.aggregate.rejection.TaskPartRejections.ChangeStatusRejections;
+import io.spine.examples.todolist.c.aggregate.rejection.TaskPartRejections.UpdateRejections;
 import io.spine.examples.todolist.c.commands.CreateDraft;
 import io.spine.examples.todolist.c.commands.UpdateTaskDescription;
 import io.spine.examples.todolist.c.commands.UpdateTaskDueDate;
-import io.spine.examples.todolist.c.failures.CannotCreateDraft;
-import io.spine.examples.todolist.c.failures.CannotUpdateTaskDescription;
-import io.spine.examples.todolist.c.failures.CannotUpdateTaskDueDate;
+import io.spine.examples.todolist.c.rejection.CannotCreateDraft;
+import io.spine.examples.todolist.c.rejection.CannotUpdateTaskDescription;
+import io.spine.examples.todolist.c.rejection.CannotUpdateTaskDueDate;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import static io.spine.examples.todolist.c.aggregate.failures.TaskPartFailures.TaskCreationFailures.throwCannotCreateDraftFailure;
-import static io.spine.examples.todolist.c.aggregate.failures.TaskPartFailures.UpdateFailures.throwCannotUpdateTaskDescription;
-import static io.spine.examples.todolist.c.aggregate.failures.TaskPartFailures.UpdateFailures.throwCannotUpdateTaskDueDate;
+import static io.spine.examples.todolist.c.aggregate.rejection.TaskPartRejections.TaskCreationRejections.throwCannotCreateDraft;
+import static io.spine.examples.todolist.c.aggregate.rejection.TaskPartRejections.UpdateRejections.throwCannotUpdateTaskDescription;
+import static io.spine.examples.todolist.c.aggregate.rejection.TaskPartRejections.UpdateRejections.throwCannotUpdateTaskDueDate;
 import static io.spine.test.Tests.assertHasPrivateParameterlessCtor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -53,85 +52,84 @@ class TaskPartRejectionsTest {
     @Test
     @DisplayName("have the private constructor")
     void havePrivateConstructor() {
-        assertHasPrivateParameterlessCtor(TaskPartFailures.class);
+        assertHasPrivateParameterlessCtor(TaskPartRejections.class);
     }
 
     @Nested
-    @DisplayName("ChangeStatusFailures should")
-    class ChangeStatusFailuresTest {
+    @DisplayName("ChangeStatusRejections should")
+    class ChangeStatusRejectionsTest {
 
         @Test
         @DisplayName("have the private constructor")
         void havePrivateConstructor() {
-            assertHasPrivateParameterlessCtor(ChangeStatusFailures.class);
+            assertHasPrivateParameterlessCtor(ChangeStatusRejections.class);
         }
     }
 
     @Nested
-    @DisplayName("TaskCreationFailures should")
-    class TaskCreationFailuresTest {
+    @DisplayName("TaskCreationRejections should")
+    class TaskCreationRejectionsTest {
 
         @Test
         @DisplayName("have the private constructor")
         void havePrivateConstructor() {
-            assertHasPrivateParameterlessCtor(TaskCreationFailures.class);
+            assertHasPrivateParameterlessCtor(TaskPartRejections.TaskCreationRejections.class);
         }
 
         @Test
-        @DisplayName("throw CannotCreateDraft failure")
-        void throwCannotCreateDraft() {
+        @DisplayName("throw CannotCreateDraft rejection")
+        void throwCannotCreateDraftRejection() {
             final CreateDraft cmd = CreateDraft.newBuilder()
                                                .setId(taskId)
                                                .build();
-            final CannotCreateDraft failure = assertThrows(CannotCreateDraft.class,
-                                                           () -> throwCannotCreateDraftFailure(
-                                                                   cmd));
-            final TaskId actual = failure.getMessageThrown()
-                                         .getCreateDraftFailed()
-                                         .getFailureDetails()
-                                         .getTaskId();
+            final CannotCreateDraft rejection = assertThrows(CannotCreateDraft.class,
+                                                             () -> throwCannotCreateDraft(cmd));
+            final TaskId actual = rejection.getMessageThrown()
+                                           .getCreateDraftFailed()
+                                           .getRejectionDetails()
+                                           .getTaskId();
             assertEquals(taskId, actual);
         }
     }
 
     @Nested
-    @DisplayName("UpdateFailures should")
-    class UpdateFailuresTest {
+    @DisplayName("UpdateRejections should")
+    class UpdateRejectionsTest {
 
         @Test
         @DisplayName("have the private constructor")
         void havePrivateConstructor() {
-            assertHasPrivateParameterlessCtor(UpdateFailures.class);
+            assertHasPrivateParameterlessCtor(UpdateRejections.class);
         }
 
         @Test
-        @DisplayName("throw CannotUpdateTaskDueDate failure")
-        void throwCannotUpdateTaskDueDateFailure() {
+        @DisplayName("throw CannotUpdateTaskDueDate rejection")
+        void throwCannotUpdateTaskDueDateRejection() {
             final UpdateTaskDueDate cmd = UpdateTaskDueDate.newBuilder()
                                                            .setId(taskId)
                                                            .build();
-            final CannotUpdateTaskDueDate failure =
+            final CannotUpdateTaskDueDate rejection =
                     assertThrows(CannotUpdateTaskDueDate.class,
                                  () -> throwCannotUpdateTaskDueDate(cmd));
-            final FailedTaskCommandDetails failedCommand = failure.getMessageThrown()
-                                                                  .getUpdateFailed()
-                                                                  .getFailureDetails();
+            final FailedTaskCommandDetails failedCommand = rejection.getMessageThrown()
+                                                                    .getUpdateFailed()
+                                                                    .getRejectionDetails();
             final TaskId actualId = failedCommand.getTaskId();
             assertEquals(taskId, actualId);
         }
 
         @Test
-        @DisplayName("throw CannotUpdateTaskDescription failure")
-        void throwCannotUpdateTaskDescriptionFailure() {
+        @DisplayName("throw CannotUpdateTaskDescription rejection")
+        void throwCannotUpdateTaskDescriptionRejection() {
             final UpdateTaskDescription cmd = UpdateTaskDescription.newBuilder()
                                                                    .setId(taskId)
                                                                    .build();
-            final CannotUpdateTaskDescription failure =
+            final CannotUpdateTaskDescription rejection =
                     assertThrows(CannotUpdateTaskDescription.class,
                                  () -> throwCannotUpdateTaskDescription(cmd));
-            final FailedTaskCommandDetails failedCommand = failure.getMessageThrown()
-                                                                  .getUpdateFailed()
-                                                                  .getFailureDetails();
+            final FailedTaskCommandDetails failedCommand = rejection.getMessageThrown()
+                                                                    .getUpdateFailed()
+                                                                    .getRejectionDetails();
             final TaskId actualId = failedCommand.getTaskId();
             assertEquals(taskId, actualId);
         }

--- a/model/src/main/proto/todolist/c/rejections.proto
+++ b/model/src/main/proto/todolist/c/rejections.proto
@@ -25,7 +25,7 @@ package spine.examples.todolist;
 import "spine/options.proto";
 
 option (type_url_prefix) = "type.spine.examples.todolist";
-option java_package = "io.spine.examples.todolist.c.failures";
+option java_package = "io.spine.examples.todolist.c.rejection";
 option java_multiple_files = false;
 option java_generate_equals_and_hash = true;
 
@@ -33,7 +33,7 @@ option java_generate_equals_and_hash = true;
 import "todolist/identifiers.proto";
 import "todolist/values.proto";
 
-// The failure to update a task description.
+// The rejection to update a task description.
 //
 // It is thrown if an attempt is made to update the task in either DELETED or COMPLETED state.
 message CannotUpdateTaskDescription {
@@ -42,7 +42,7 @@ message CannotUpdateTaskDescription {
     DescriptionUpdateFailed update_failed = 1;
 }
 
-// The failure to update a task priority.
+// The rejection to update a task priority.
 //
 // It is thrown if an attempt is made to update the task in either DELETED or COMPLETED state.
 message CannotUpdateTaskPriority {
@@ -51,7 +51,7 @@ message CannotUpdateTaskPriority {
     PriorityUpdateFailed update_failed = 1;
 }
 
-// The failure to update a task due date.
+// The rejection to update a task due date.
 //
 // It is thrown if an attempt is made to update the task in either DELETED or COMPLETED state.
 message CannotUpdateTaskDueDate {
@@ -60,7 +60,7 @@ message CannotUpdateTaskDueDate {
     TaskDueDateUpdateFailed update_failed = 1;
 }
 
-// The failure to update a label details.
+// The rejection to update a label details.
 //
 // It is thrown if an attempt is made to update the label when
 // the expected label details do not match the actual.
@@ -70,7 +70,7 @@ message CannotUpdateLabelDetails {
     LabelDetailsUpdateFailed update_failed = 1;
 }
 
-// The failure to assign label to task.
+// The rejection to assign label to task.
 //
 // It is thrown if an attempt is made to assign the label
 // to the task in either DELETED or COMPLETED state.
@@ -80,7 +80,7 @@ message CannotAssignLabelToTask {
     AssignLabelToTaskFailed assign_label_failed = 1;
 }
 
-// The failure to remove label from task.
+// The rejection to remove label from task.
 //
 // It is thrown if an attempt is made to remove the label
 // from the task in either DELETED or COMPLETED state.
@@ -90,7 +90,7 @@ message CannotRemoveLabelFromTask {
     RemoveLabelFromTaskFailed remove_label_failed = 1;
 }
 
-// The failure to reopen a task.
+// The rejection to reopen a task.
 //
 // It is thrown if an attempt is made to reopen the task when task is not COMPLETED.
 message CannotReopenTask {
@@ -99,7 +99,7 @@ message CannotReopenTask {
     ReopenTaskFailed reopen_task_failed = 1;
 }
 
-// The failure to delete a task.
+// The rejection to delete a task.
 //
 // It is thrown if an attempt is made to delete the task
 // when task in either DELETED or COMPLETED state.
@@ -109,7 +109,7 @@ message CannotDeleteTask {
     DeleteTaskFailed delete_task_failed = 1;
 }
 
-// The failure to restore a task.
+// The rejection to restore a task.
 //
 // It is thrown if an attempt is made to restore the task when task is not DELETED.
 message CannotRestoreDeletedTask {
@@ -118,7 +118,7 @@ message CannotRestoreDeletedTask {
     RestoreDeletedTaskFailed restore_task_failed = 1;
 }
 
-// The failure to complete a task.
+// The rejection to complete a task.
 //
 // It is thrown if an attempt is made to complete the task when task is not FINALIZED.
 message CannotCompleteTask {
@@ -127,7 +127,7 @@ message CannotCompleteTask {
     CompleteTaskFailed complete_task_failed = 1;
 }
 
-// The failure to create a task draft.
+// The rejection to create a task draft.
 //
 // It is thrown if an attempt is made to create the task draft when task is already has a state.
 message CannotCreateDraft {
@@ -136,7 +136,7 @@ message CannotCreateDraft {
     CreateDraftFailed create_draft_failed = 1;
 }
 
-// The failure to finalize a draft.
+// The rejection to finalize a draft.
 //
 // It is thrown if an attempt is made to finalize the task when task is not DRAFT.
 message CannotFinalizeDraft {

--- a/model/src/main/proto/todolist/c/rejections.proto
+++ b/model/src/main/proto/todolist/c/rejections.proto
@@ -38,8 +38,8 @@ import "todolist/values.proto";
 // It is thrown if an attempt is made to update the task in either DELETED or COMPLETED state.
 message CannotUpdateTaskDescription {
 
-    // Failed the description update.
-    DescriptionUpdateFailed update_failed = 1;
+    // Rejected the description update.
+    DescriptionUpdateRejected update_rejected = 1;
 }
 
 // The rejection to update a task priority.
@@ -47,8 +47,8 @@ message CannotUpdateTaskDescription {
 // It is thrown if an attempt is made to update the task in either DELETED or COMPLETED state.
 message CannotUpdateTaskPriority {
 
-    // Failed the priority update.
-    PriorityUpdateFailed update_failed = 1;
+    // Rejected the priority update.
+    PriorityUpdateRejected update_rejected = 1;
 }
 
 // The rejection to update a task due date.
@@ -56,8 +56,8 @@ message CannotUpdateTaskPriority {
 // It is thrown if an attempt is made to update the task in either DELETED or COMPLETED state.
 message CannotUpdateTaskDueDate {
 
-    // Failed the due date update.
-    TaskDueDateUpdateFailed update_failed = 1;
+    // Rejected the due date update.
+    TaskDueDateUpdateRejected update_rejected = 1;
 }
 
 // The rejection to update a label details.
@@ -66,8 +66,8 @@ message CannotUpdateTaskDueDate {
 // the expected label details do not match the actual.
 message CannotUpdateLabelDetails {
 
-    // Failed the label details update.
-    LabelDetailsUpdateFailed update_failed = 1;
+    // Rejected the label details update.
+    LabelDetailsUpdateRejected update_rejected = 1;
 }
 
 // The rejection to assign label to task.
@@ -76,8 +76,8 @@ message CannotUpdateLabelDetails {
 // to the task in either DELETED or COMPLETED state.
 message CannotAssignLabelToTask {
 
-    // Failed the label assigning to the task.
-    AssignLabelToTaskFailed assign_label_failed = 1;
+    // Rejected the label assigning to the task.
+    AssignLabelToTaskRejected assign_label_rejected = 1;
 }
 
 // The rejection to remove label from task.
@@ -86,8 +86,8 @@ message CannotAssignLabelToTask {
 // from the task in either DELETED or COMPLETED state.
 message CannotRemoveLabelFromTask {
 
-    // Failed the label removing from task.
-    RemoveLabelFromTaskFailed remove_label_failed = 1;
+    // Rejected the label removing from task.
+    RemoveLabelFromTaskRejected remove_label_rejected = 1;
 }
 
 // The rejection to reopen a task.
@@ -95,8 +95,8 @@ message CannotRemoveLabelFromTask {
 // It is thrown if an attempt is made to reopen the task when task is not COMPLETED.
 message CannotReopenTask {
 
-    // Failed the task reopening.
-    ReopenTaskFailed reopen_task_failed = 1;
+    // Rejected the task reopening.
+    ReopenTaskRejected reopen_task_rejected = 1;
 }
 
 // The rejection to delete a task.
@@ -105,8 +105,8 @@ message CannotReopenTask {
 // when task in either DELETED or COMPLETED state.
 message CannotDeleteTask {
 
-    // Failed the task deletion.
-    DeleteTaskFailed delete_task_failed = 1;
+    // Rejected the task deletion.
+    DeleteTaskRejected delete_task_rejected = 1;
 }
 
 // The rejection to restore a task.
@@ -114,8 +114,8 @@ message CannotDeleteTask {
 // It is thrown if an attempt is made to restore the task when task is not DELETED.
 message CannotRestoreDeletedTask {
 
-    // Failed the task restoring.
-    RestoreDeletedTaskFailed restore_task_failed = 1;
+    // Rejected the task restoring.
+    RestoreDeletedTaskRejected restore_task_rejected = 1;
 }
 
 // The rejection to complete a task.
@@ -123,8 +123,8 @@ message CannotRestoreDeletedTask {
 // It is thrown if an attempt is made to complete the task when task is not FINALIZED.
 message CannotCompleteTask {
 
-    // Failed the task completion.
-    CompleteTaskFailed complete_task_failed = 1;
+    // Rejected the task completion.
+    CompleteTaskRejected complete_task_rejected = 1;
 }
 
 // The rejection to create a task draft.
@@ -132,8 +132,8 @@ message CannotCompleteTask {
 // It is thrown if an attempt is made to create the task draft when task is already has a state.
 message CannotCreateDraft {
 
-    // Failed the draft creation.
-    CreateDraftFailed create_draft_failed = 1;
+    // Rejected the draft creation.
+    CreateDraftRejected create_draft_rejected = 1;
 }
 
 // The rejection to finalize a draft.
@@ -141,6 +141,6 @@ message CannotCreateDraft {
 // It is thrown if an attempt is made to finalize the task when task is not DRAFT.
 message CannotFinalizeDraft {
 
-    // Failed the draft finalization.
-    FinalizeDraftFailed finalize_draft_failed = 1;
+    // Rejected the draft finalization.
+    FinalizeDraftRejected finalize_draft_rejected = 1;
 }

--- a/model/src/main/proto/todolist/c/rejections.proto
+++ b/model/src/main/proto/todolist/c/rejections.proto
@@ -38,8 +38,8 @@ import "todolist/values.proto";
 // It is thrown if an attempt is made to update the task in either DELETED or COMPLETED state.
 message CannotUpdateTaskDescription {
 
-    // Rejected the description update.
-    DescriptionUpdateRejected update_rejected = 1;
+    // Details of the rejection.
+    DescriptionUpdateRejected rejection_details = 1;
 }
 
 // The rejection to update a task priority.
@@ -47,8 +47,8 @@ message CannotUpdateTaskDescription {
 // It is thrown if an attempt is made to update the task in either DELETED or COMPLETED state.
 message CannotUpdateTaskPriority {
 
-    // Rejected the priority update.
-    PriorityUpdateRejected update_rejected = 1;
+    // Details of the rejection.
+    PriorityUpdateRejected rejection_details = 1;
 }
 
 // The rejection to update a task due date.
@@ -56,8 +56,8 @@ message CannotUpdateTaskPriority {
 // It is thrown if an attempt is made to update the task in either DELETED or COMPLETED state.
 message CannotUpdateTaskDueDate {
 
-    // Rejected the due date update.
-    TaskDueDateUpdateRejected update_rejected = 1;
+    // Details of the rejection.
+    TaskDueDateUpdateRejected rejection_details = 1;
 }
 
 // The rejection to update a label details.
@@ -66,8 +66,8 @@ message CannotUpdateTaskDueDate {
 // the expected label details do not match the actual.
 message CannotUpdateLabelDetails {
 
-    // Rejected the label details update.
-    LabelDetailsUpdateRejected update_rejected = 1;
+    // Details of the rejection.
+    LabelDetailsUpdateRejected rejection_details = 1;
 }
 
 // The rejection to assign label to task.
@@ -76,8 +76,8 @@ message CannotUpdateLabelDetails {
 // to the task in either DELETED or COMPLETED state.
 message CannotAssignLabelToTask {
 
-    // Rejected the label assigning to the task.
-    AssignLabelToTaskRejected assign_label_rejected = 1;
+    // Details of the rejection.
+    AssignLabelToTaskRejected rejection_details = 1;
 }
 
 // The rejection to remove label from task.
@@ -86,8 +86,8 @@ message CannotAssignLabelToTask {
 // from the task in either DELETED or COMPLETED state.
 message CannotRemoveLabelFromTask {
 
-    // Rejected the label removing from task.
-    RemoveLabelFromTaskRejected remove_label_rejected = 1;
+    // Details of the rejection.
+    RemoveLabelFromTaskRejected rejection_details = 1;
 }
 
 // The rejection to reopen a task.
@@ -95,8 +95,8 @@ message CannotRemoveLabelFromTask {
 // It is thrown if an attempt is made to reopen the task when task is not COMPLETED.
 message CannotReopenTask {
 
-    // Rejected the task reopening.
-    ReopenTaskRejected reopen_task_rejected = 1;
+    // Details of the rejection.
+    ReopenTaskRejected rejection_details = 1;
 }
 
 // The rejection to delete a task.
@@ -105,8 +105,8 @@ message CannotReopenTask {
 // when task in either DELETED or COMPLETED state.
 message CannotDeleteTask {
 
-    // Rejected the task deletion.
-    DeleteTaskRejected delete_task_rejected = 1;
+    // Details of the rejection.
+    DeleteTaskRejected rejection_details = 1;
 }
 
 // The rejection to restore a task.
@@ -114,8 +114,8 @@ message CannotDeleteTask {
 // It is thrown if an attempt is made to restore the task when task is not DELETED.
 message CannotRestoreDeletedTask {
 
-    // Rejected the task restoring.
-    RestoreDeletedTaskRejected restore_task_rejected = 1;
+    // Details of the rejection.
+    RestoreDeletedTaskRejected rejection_details = 1;
 }
 
 // The rejection to complete a task.
@@ -123,8 +123,8 @@ message CannotRestoreDeletedTask {
 // It is thrown if an attempt is made to complete the task when task is not FINALIZED.
 message CannotCompleteTask {
 
-    // Rejected the task completion.
-    CompleteTaskRejected complete_task_rejected = 1;
+    // Details of the rejection.
+    CompleteTaskRejected rejection_details = 1;
 }
 
 // The rejection to create a task draft.
@@ -132,8 +132,8 @@ message CannotCompleteTask {
 // It is thrown if an attempt is made to create the task draft when task is already has a state.
 message CannotCreateDraft {
 
-    // Rejected the draft creation.
-    CreateDraftRejected create_draft_rejected = 1;
+    // Details of the rejection.
+    CreateDraftRejected rejection_details = 1;
 }
 
 // The rejection to finalize a draft.
@@ -141,6 +141,6 @@ message CannotCreateDraft {
 // It is thrown if an attempt is made to finalize the task when task is not DRAFT.
 message CannotFinalizeDraft {
 
-    // Rejected the draft finalization.
-    FinalizeDraftRejected finalize_draft_rejected = 1;
+    // Details of the rejection.
+    FinalizeDraftRejected rejection_details = 1;
 }

--- a/model/src/main/proto/todolist/values.proto
+++ b/model/src/main/proto/todolist/values.proto
@@ -85,8 +85,8 @@ message LabelDetails {
 // DTO for the description mismatch.
 message DescriptionUpdateRejected {
 
-    // Unsuccessful task command.
-    RejectedTaskCommandDetails rejection_details = 1;
+    // An unsuccessful task command details.
+    RejectedTaskCommandDetails command_details = 1;
 
     // A mismatching description value.
     change.ValueMismatch description_mismatch = 2;
@@ -95,8 +95,8 @@ message DescriptionUpdateRejected {
 // DTO for the priority mismatch.
 message PriorityUpdateRejected {
 
-    // Unsuccessful task command.
-    RejectedTaskCommandDetails rejection_details = 1;
+    // An unsuccessful task command details.
+    RejectedTaskCommandDetails command_details = 1;
 
     // A mismatching priority value.
     change.ValueMismatch priority_mismatch = 2;
@@ -105,8 +105,8 @@ message PriorityUpdateRejected {
 // DTO for the due date mismatch.
 message TaskDueDateUpdateRejected {
 
-    // Unsuccessful task command.
-    RejectedTaskCommandDetails rejection_details = 1;
+    // An unsuccessful task command details.
+    RejectedTaskCommandDetails command_details = 1;
 
     // A mismatching due date value.
     change.ValueMismatch due_date_mismatch = 2;
@@ -115,90 +115,90 @@ message TaskDueDateUpdateRejected {
 // DTO for the label details mismatch.
 message LabelDetailsUpdateRejected {
 
-    // Unsuccessful label command.
-    RejectedLabelCommandDetails rejection_details = 1;
+    // An unsuccessful label command details.
+    RejectedLabelCommandDetails command_details = 1;
 
     // A mismatching label details value.
     change.ValueMismatch label_details_mismatch = 2;
 }
 
-// DTO for the rejected craete basic task command.
+// DTO for the rejected craete basic task command details.
 message CreateBasicTaskRejected {
 
-    // Unsuccessful task command.
-    RejectedTaskCommandDetails rejection_details = 1;
+    // An unsuccessful task command details.
+    RejectedTaskCommandDetails command_details = 1;
 }
 
-// DTO for the rejected assign label to task command.
+// DTO for the rejected assign label to task command details.
 message AssignLabelToTaskRejected {
 
-    // Unsuccessful task command.
-    RejectedTaskCommandDetails rejection_details = 1;
+    // An unsuccessful task command details.
+    RejectedTaskCommandDetails command_details = 1;
 
     // An identifier of the label.
     LabelId label_id = 2;
 }
 
-// DTO for the rejected remove label from task command.
+// DTO for the rejected remove label from task command details.
 message RemoveLabelFromTaskRejected {
 
-    // An unsuccessful task command.
-    RejectedTaskCommandDetails rejection_details = 1;
+    // An unsuccessful task command details.
+    RejectedTaskCommandDetails command_details = 1;
 
     // An identifier of the label.
     LabelId label_id = 2;
 }
 
-// DTO for the rejected reopen task command.
+// DTO for the rejected reopen task command details.
 message ReopenTaskRejected {
 
-    // An unsuccessful task command.
-    RejectedTaskCommandDetails rejection_details = 1;
+    // An unsuccessful task command details.
+    RejectedTaskCommandDetails command_details = 1;
 }
 
-// DTO for the rejected delete task command.
+// DTO for the rejected delete task command details.
 message DeleteTaskRejected {
 
-    // An unsuccessful task command.
-    RejectedTaskCommandDetails rejection_details = 1;
+    // An unsuccessful task command details.
+    RejectedTaskCommandDetails command_details = 1;
 }
 
-// DTO for the rejected restore deleted task command.
+// DTO for the rejected restore deleted task command details.
 message RestoreDeletedTaskRejected {
 
-    // An unsuccessful task command.
-    RejectedTaskCommandDetails rejection_details = 1;
+    // An unsuccessful task command details.
+    RejectedTaskCommandDetails command_details = 1;
 }
 
-// DTO for the rejected complete task command.
+// DTO for the rejected complete task command details.
 message CompleteTaskRejected {
 
-    // An unsuccessful task command.
-    RejectedTaskCommandDetails rejection_details = 1;
+    // An unsuccessful task command details.
+    RejectedTaskCommandDetails command_details = 1;
 }
 
-// DTO for the rejected create task draft command.
+// DTO for the rejected create task draft command details.
 message CreateDraftRejected {
 
-    // An unsuccessful task command.
-    RejectedTaskCommandDetails rejection_details = 1;
+    // An unsuccessful task command details.
+    RejectedTaskCommandDetails command_details = 1;
 }
 
-// DTO for the rejected finalize draft command.
+// DTO for the rejected finalize draft command details.
 message FinalizeDraftRejected {
 
-    // An unsuccessful task command.
-    RejectedTaskCommandDetails rejection_details = 1;
+    // An unsuccessful task command details.
+    RejectedTaskCommandDetails command_details = 1;
 }
 
-// DTO for the unsuccessful task command.
+// DTO for the unsuccessful task command details.
 message RejectedTaskCommandDetails {
 
     // A task identifier.
     TaskId task_id = 1;
 }
 
-// DTO for the unsuccessful label command.
+// DTO for the unsuccessful label command details.
 message RejectedLabelCommandDetails {
 
     // A task label identifier.

--- a/model/src/main/proto/todolist/values.proto
+++ b/model/src/main/proto/todolist/values.proto
@@ -83,123 +83,123 @@ message LabelDetails {
 }
 
 // DTO for the description mismatch.
-message DescriptionUpdateFailed {
+message DescriptionUpdateRejected {
 
     // Unsuccessful task command.
-    FailedTaskCommandDetails rejection_details = 1;
+    RejectedTaskCommandDetails rejection_details = 1;
 
     // A mismatching description value.
     change.ValueMismatch description_mismatch = 2;
 }
 
 // DTO for the priority mismatch.
-message PriorityUpdateFailed {
+message PriorityUpdateRejected {
 
     // Unsuccessful task command.
-    FailedTaskCommandDetails rejection_details = 1;
+    RejectedTaskCommandDetails rejection_details = 1;
 
     // A mismatching priority value.
     change.ValueMismatch priority_mismatch = 2;
 }
 
 // DTO for the due date mismatch.
-message TaskDueDateUpdateFailed {
+message TaskDueDateUpdateRejected {
 
     // Unsuccessful task command.
-    FailedTaskCommandDetails rejection_details = 1;
+    RejectedTaskCommandDetails rejection_details = 1;
 
     // A mismatching due date value.
     change.ValueMismatch due_date_mismatch = 2;
 }
 
 // DTO for the label details mismatch.
-message LabelDetailsUpdateFailed {
+message LabelDetailsUpdateRejected {
 
     // Unsuccessful label command.
-    FailedLabelCommandDetails rejection_details = 1;
+    RejectedLabelCommandDetails rejection_details = 1;
 
     // A mismatching label details value.
     change.ValueMismatch label_details_mismatch = 2;
 }
 
-// DTO for the failed craete basic task command.
-message CreateBasicTaskFailed {
+// DTO for the rejected craete basic task command.
+message CreateBasicTaskRejected {
 
     // Unsuccessful task command.
-    FailedTaskCommandDetails rejection_details = 1;
+    RejectedTaskCommandDetails rejection_details = 1;
 }
 
-// DTO for the failed assign label to task command.
-message AssignLabelToTaskFailed {
+// DTO for the rejected assign label to task command.
+message AssignLabelToTaskRejected {
 
     // Unsuccessful task command.
-    FailedTaskCommandDetails rejection_details = 1;
+    RejectedTaskCommandDetails rejection_details = 1;
 
     // An identifier of the label.
     LabelId label_id = 2;
 }
 
-// DTO for the failed remove label from task command.
-message RemoveLabelFromTaskFailed {
+// DTO for the rejected remove label from task command.
+message RemoveLabelFromTaskRejected {
 
     // An unsuccessful task command.
-    FailedTaskCommandDetails rejection_details = 1;
+    RejectedTaskCommandDetails rejection_details = 1;
 
     // An identifier of the label.
     LabelId label_id = 2;
 }
 
-// DTO for the failed reopen task command.
-message ReopenTaskFailed {
+// DTO for the rejected reopen task command.
+message ReopenTaskRejected {
 
     // An unsuccessful task command.
-    FailedTaskCommandDetails rejection_details = 1;
+    RejectedTaskCommandDetails rejection_details = 1;
 }
 
-// DTO for the failed delete task command.
-message DeleteTaskFailed {
+// DTO for the rejected delete task command.
+message DeleteTaskRejected {
 
     // An unsuccessful task command.
-    FailedTaskCommandDetails rejection_details = 1;
+    RejectedTaskCommandDetails rejection_details = 1;
 }
 
-// DTO for the failed restore deleted task command.
-message RestoreDeletedTaskFailed {
+// DTO for the rejected restore deleted task command.
+message RestoreDeletedTaskRejected {
 
     // An unsuccessful task command.
-    FailedTaskCommandDetails rejection_details = 1;
+    RejectedTaskCommandDetails rejection_details = 1;
 }
 
-// DTO for the failed complete task command.
-message CompleteTaskFailed {
+// DTO for the rejected complete task command.
+message CompleteTaskRejected {
 
     // An unsuccessful task command.
-    FailedTaskCommandDetails rejection_details = 1;
+    RejectedTaskCommandDetails rejection_details = 1;
 }
 
-// DTO for the failed create task draft command.
-message CreateDraftFailed {
+// DTO for the rejected create task draft command.
+message CreateDraftRejected {
 
     // An unsuccessful task command.
-    FailedTaskCommandDetails rejection_details = 1;
+    RejectedTaskCommandDetails rejection_details = 1;
 }
 
-// DTO for the failed finalize draft command.
-message FinalizeDraftFailed {
+// DTO for the rejected finalize draft command.
+message FinalizeDraftRejected {
 
     // An unsuccessful task command.
-    FailedTaskCommandDetails rejection_details = 1;
+    RejectedTaskCommandDetails rejection_details = 1;
 }
 
 // DTO for the unsuccessful task command.
-message FailedTaskCommandDetails {
+message RejectedTaskCommandDetails {
 
     // A task identifier.
     TaskId task_id = 1;
 }
 
 // DTO for the unsuccessful label command.
-message FailedLabelCommandDetails {
+message RejectedLabelCommandDetails {
 
     // A task label identifier.
     LabelId label_id = 1;

--- a/model/src/main/proto/todolist/values.proto
+++ b/model/src/main/proto/todolist/values.proto
@@ -86,7 +86,7 @@ message LabelDetails {
 message DescriptionUpdateFailed {
 
     // Unsuccessful task command.
-    FailedTaskCommandDetails failure_details = 1;
+    FailedTaskCommandDetails rejection_details = 1;
 
     // A mismatching description value.
     change.ValueMismatch description_mismatch = 2;
@@ -96,7 +96,7 @@ message DescriptionUpdateFailed {
 message PriorityUpdateFailed {
 
     // Unsuccessful task command.
-    FailedTaskCommandDetails failure_details = 1;
+    FailedTaskCommandDetails rejection_details = 1;
 
     // A mismatching priority value.
     change.ValueMismatch priority_mismatch = 2;
@@ -106,7 +106,7 @@ message PriorityUpdateFailed {
 message TaskDueDateUpdateFailed {
 
     // Unsuccessful task command.
-    FailedTaskCommandDetails failure_details = 1;
+    FailedTaskCommandDetails rejection_details = 1;
 
     // A mismatching due date value.
     change.ValueMismatch due_date_mismatch = 2;
@@ -116,7 +116,7 @@ message TaskDueDateUpdateFailed {
 message LabelDetailsUpdateFailed {
 
     // Unsuccessful label command.
-    FailedLabelCommandDetails failure_details = 1;
+    FailedLabelCommandDetails rejection_details = 1;
 
     // A mismatching label details value.
     change.ValueMismatch label_details_mismatch = 2;
@@ -126,14 +126,14 @@ message LabelDetailsUpdateFailed {
 message CreateBasicTaskFailed {
 
     // Unsuccessful task command.
-    FailedTaskCommandDetails failure_details = 1;
+    FailedTaskCommandDetails rejection_details = 1;
 }
 
 // DTO for the failed assign label to task command.
 message AssignLabelToTaskFailed {
 
     // Unsuccessful task command.
-    FailedTaskCommandDetails failure_details = 1;
+    FailedTaskCommandDetails rejection_details = 1;
 
     // An identifier of the label.
     LabelId label_id = 2;
@@ -143,7 +143,7 @@ message AssignLabelToTaskFailed {
 message RemoveLabelFromTaskFailed {
 
     // An unsuccessful task command.
-    FailedTaskCommandDetails failure_details = 1;
+    FailedTaskCommandDetails rejection_details = 1;
 
     // An identifier of the label.
     LabelId label_id = 2;
@@ -153,42 +153,42 @@ message RemoveLabelFromTaskFailed {
 message ReopenTaskFailed {
 
     // An unsuccessful task command.
-    FailedTaskCommandDetails failure_details = 1;
+    FailedTaskCommandDetails rejection_details = 1;
 }
 
 // DTO for the failed delete task command.
 message DeleteTaskFailed {
 
     // An unsuccessful task command.
-    FailedTaskCommandDetails failure_details = 1;
+    FailedTaskCommandDetails rejection_details = 1;
 }
 
 // DTO for the failed restore deleted task command.
 message RestoreDeletedTaskFailed {
 
     // An unsuccessful task command.
-    FailedTaskCommandDetails failure_details = 1;
+    FailedTaskCommandDetails rejection_details = 1;
 }
 
 // DTO for the failed complete task command.
 message CompleteTaskFailed {
 
     // An unsuccessful task command.
-    FailedTaskCommandDetails failure_details = 1;
+    FailedTaskCommandDetails rejection_details = 1;
 }
 
 // DTO for the failed create task draft command.
 message CreateDraftFailed {
 
     // An unsuccessful task command.
-    FailedTaskCommandDetails failure_details = 1;
+    FailedTaskCommandDetails rejection_details = 1;
 }
 
 // DTO for the failed finalize draft command.
 message FinalizeDraftFailed {
 
     // An unsuccessful task command.
-    FailedTaskCommandDetails failure_details = 1;
+    FailedTaskCommandDetails rejection_details = 1;
 }
 
 // DTO for the unsuccessful task command.


### PR DESCRIPTION
This PR renames failures to rejections, because the `Failure` concept has been migrated to `Rejections` in core Spine.

The `failures` package was renamed to to a singular version - `rejection`.