### PR TITLE
Apply `spine-model-verifier` plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,7 +46,8 @@ buildscript {
         classpath appEngineGradlePlugin
         classpath 'org.akhikhl.gretty:gretty:+'
         classpath "org.junit.platform:junit-platform-gradle-plugin:${jUnitPlatformVersion}"
-        classpath "io.spine.tools:spine-model-compiler:$spineBaseVersion"
+        classpath "io.spine.tools:spine-model-compiler:${spineBaseVersion}"
+        classpath "io.spine.tools:spine-model-verifier:${spineVersion}"
     }
 
     // The below suppressions `GroovyAssignabilityCheck` is a workaround for the IDEA bug.
@@ -140,6 +141,13 @@ subprojects {
     apply plugin: 'com.google.protobuf'
     apply plugin: 'org.junit.platform.gradle.plugin'
     apply plugin: 'io.spine.tools.spine-model-compiler'
+    apply plugin: 'io.spine.tools.spine-model-verifier'
+
+    compileJava {
+        // The configuration for `spine-model-verifier`.
+        options.compilerArgs += ["-processor", "io.spine.model.assemble.AssignLookup",
+                                 "-AspineDirRoot=${rootDir}"]
+    }
 
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
@@ -163,6 +171,7 @@ subprojects {
         compile group: 'io.spine', name: 'spine-base', version: spineBaseVersion
         compile group: 'io.spine', name: 'spine-client', version: spineVersion
         compile group: 'io.spine', name: 'spine-server', version: spineVersion
+        compileOnly group: 'io.spine.tools', name: 'spine-model-assembler', version: spineVersion
 
         testCompile group: 'org.hamcrest', name: 'hamcrest-all', version: '1.3'
         testCompile("io.spine:spine-testutil-base:${spineBaseVersion}") {

--- a/ext.gradle
+++ b/ext.gradle
@@ -19,7 +19,7 @@
  */
 
 
-final def SPINE_VERSION = '0.9.71-SNAPSHOT'
+final def SPINE_VERSION = '0.9.72-SNAPSHOT'
 
 project.ext {
     // TODOList version

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.2-bin.zip


### PR DESCRIPTION
This PR applies `spine-model-verifier` plugin. Currently, this plugin checks correctness of command handlers (methods, which are marked with `@Assign`). If the application model is invalid, the plugin fails a build.

More details about the plugin can be found [here](https://github.com/SpineEventEngine/core-java/pull/576).

Besides this, the Gradle version was increased to `4.2`.