### PR TITLE
Fix the events applying

### DIFF
--- a/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/TaskLabelsPart.java
+++ b/api-java/src/main/java/io/spine/examples/todolist/c/aggregate/TaskLabelsPart.java
@@ -108,8 +108,8 @@ public class TaskLabelsPart
 
     @Apply
     private void labelAssignedToTask(LabelAssignedToTask event) {
-        final Collection<LabelId> list = new ArrayList<>(getState().getLabelIdsList()
-                                                                   .getIdsList());
+        final Collection<LabelId> list = new ArrayList<>(getBuilder().getLabelIdsList()
+                                                                     .getIdsList());
         list.add(event.getLabelId());
         final LabelIdsList labelIdsList = LabelIdsList.newBuilder()
                                                       .addAllIds(list)
@@ -120,8 +120,8 @@ public class TaskLabelsPart
 
     @Apply
     private void labelRemovedFromTask(LabelRemovedFromTask event) {
-        final Collection<LabelId> list = new ArrayList<>(getState().getLabelIdsList()
-                                                                   .getIdsList());
+        final Collection<LabelId> list = new ArrayList<>(getBuilder().getLabelIdsList()
+                                                                     .getIdsList());
         list.remove(event.getLabelId());
         final LabelIdsList labelIdsList = LabelIdsList.newBuilder()
                                                       .addAllIds(list)

--- a/api-java/src/main/java/io/spine/examples/todolist/c/procman/TaskCreationWizard.java
+++ b/api-java/src/main/java/io/spine/examples/todolist/c/procman/TaskCreationWizard.java
@@ -201,7 +201,7 @@ public class TaskCreationWizard extends ProcessManager<TaskCreationId,
      * @return the ID of the supervised task
      */
     private TaskId taskId() {
-        return getState().getTaskId();
+        return getBuilder().getTaskId();
     }
 
     /**
@@ -223,7 +223,7 @@ public class TaskCreationWizard extends ProcessManager<TaskCreationId,
         if (pendingStage == CANCELED && !isTerminated()) {
             return;
         }
-        final Stage currentStage = getState().getStage();
+        final Stage currentStage = getBuilder().getStage();
         final int expectedStageNumber = currentStage.getNumber() + 1;
         final int actualStageNumber = pendingStage.getNumber();
         if (expectedStageNumber != actualStageNumber) {
@@ -237,7 +237,7 @@ public class TaskCreationWizard extends ProcessManager<TaskCreationId,
      * @return {@code true} if current process state is terminal, {@code false} otherwise
      */
     private boolean isTerminated() {
-        final Stage currentStage = getState().getStage();
+        final Stage currentStage = getBuilder().getStage();
         return currentStage == COMPLETED || currentStage == CANCELED;
     }
 

--- a/api-java/src/main/java/io/spine/examples/todolist/q/projection/DraftTasksViewProjection.java
+++ b/api-java/src/main/java/io/spine/examples/todolist/q/projection/DraftTasksViewProjection.java
@@ -37,7 +37,6 @@ import io.spine.server.projection.Projection;
 import java.util.ArrayList;
 import java.util.List;
 
-import static io.spine.Identifier.newUuid;
 import static io.spine.examples.todolist.q.projection.ProjectionHelper.newTaskListView;
 import static io.spine.examples.todolist.q.projection.ProjectionHelper.removeViewsByTaskId;
 import static io.spine.examples.todolist.q.projection.ProjectionHelper.updateTaskItemList;
@@ -83,8 +82,8 @@ public class DraftTasksViewProjection extends Projection<TaskListId,
                                           .setPriority(taskDetails.getPriority())
                                           .setCompleted(taskDetails.getCompleted())
                                           .build();
-        final List<TaskItem> views = new ArrayList<>(getState().getDraftTasks()
-                                                               .getItemsList());
+        final List<TaskItem> views = new ArrayList<>(getBuilder().getDraftTasks()
+                                                                 .getItemsList());
         views.add(taskView);
         final TaskListView taskListView = TaskListView.newBuilder()
                                                       .addAllItems(views)
@@ -94,24 +93,24 @@ public class DraftTasksViewProjection extends Projection<TaskListId,
 
     @Subscribe
     public void on(TaskDraftFinalized event) {
-        final List<TaskItem> views = new ArrayList<>(getState().getDraftTasks()
-                                                               .getItemsList());
+        final List<TaskItem> views = new ArrayList<>(getBuilder().getDraftTasks()
+                                                                 .getItemsList());
         final TaskListView taskListView = removeViewsByTaskId(views, event.getTaskId());
         getBuilder().setDraftTasks(taskListView);
     }
 
     @Subscribe
     public void on(TaskDeleted event) {
-        final List<TaskItem> views = new ArrayList<>(getState().getDraftTasks()
-                                                               .getItemsList());
+        final List<TaskItem> views = new ArrayList<>(getBuilder().getDraftTasks()
+                                                                 .getItemsList());
         final TaskListView taskListView = removeViewsByTaskId(views, event.getTaskId());
         getBuilder().setDraftTasks(taskListView);
     }
 
     @Subscribe
     public void on(TaskDescriptionUpdated event) {
-        final List<TaskItem> views = getState().getDraftTasks()
-                                               .getItemsList();
+        final List<TaskItem> views = getBuilder().getDraftTasks()
+                                                 .getItemsList();
         final List<TaskItem> updatedList = updateTaskItemList(views, event);
         final TaskListView taskListView = newTaskListView(updatedList);
         getBuilder().setDraftTasks(taskListView);
@@ -119,8 +118,8 @@ public class DraftTasksViewProjection extends Projection<TaskListId,
 
     @Subscribe
     public void on(TaskPriorityUpdated event) {
-        final List<TaskItem> views = getState().getDraftTasks()
-                                               .getItemsList();
+        final List<TaskItem> views = getBuilder().getDraftTasks()
+                                                 .getItemsList();
         final List<TaskItem> updatedList = updateTaskItemList(views, event);
         final TaskListView taskListView = newTaskListView(updatedList);
         getBuilder().setDraftTasks(taskListView);
@@ -128,8 +127,8 @@ public class DraftTasksViewProjection extends Projection<TaskListId,
 
     @Subscribe
     public void on(TaskDueDateUpdated event) {
-        final List<TaskItem> views = getState().getDraftTasks()
-                                               .getItemsList();
+        final List<TaskItem> views = getBuilder().getDraftTasks()
+                                                 .getItemsList();
         final List<TaskItem> updatedList = updateTaskItemList(views, event);
         final TaskListView taskListView = newTaskListView(updatedList);
         getBuilder().setDraftTasks(taskListView);
@@ -137,8 +136,8 @@ public class DraftTasksViewProjection extends Projection<TaskListId,
 
     @Subscribe
     public void on(LabelAssignedToTask event) {
-        final List<TaskItem> views = getState().getDraftTasks()
-                                               .getItemsList();
+        final List<TaskItem> views = getBuilder().getDraftTasks()
+                                                 .getItemsList();
         final List<TaskItem> updatedList = updateTaskItemList(views, event);
         final TaskListView taskListView = newTaskListView(updatedList);
         getBuilder().setDraftTasks(taskListView);
@@ -146,8 +145,8 @@ public class DraftTasksViewProjection extends Projection<TaskListId,
 
     @Subscribe
     public void on(LabelRemovedFromTask event) {
-        final List<TaskItem> views = getState().getDraftTasks()
-                                               .getItemsList();
+        final List<TaskItem> views = getBuilder().getDraftTasks()
+                                                 .getItemsList();
         final List<TaskItem> updatedList = updateTaskItemList(views, event);
         final TaskListView taskListView = newTaskListView(updatedList);
         getBuilder().setDraftTasks(taskListView);
@@ -155,8 +154,8 @@ public class DraftTasksViewProjection extends Projection<TaskListId,
 
     @Subscribe
     public void on(LabelDetailsUpdated event) {
-        final List<TaskItem> views = getState().getDraftTasks()
-                                               .getItemsList();
+        final List<TaskItem> views = getBuilder().getDraftTasks()
+                                                 .getItemsList();
         final List<TaskItem> updatedList = updateTaskItemList(views, event);
         final TaskListView taskListView = newTaskListView(updatedList);
         getBuilder().setDraftTasks(taskListView);

--- a/api-java/src/main/java/io/spine/examples/todolist/q/projection/LabelledTasksViewProjection.java
+++ b/api-java/src/main/java/io/spine/examples/todolist/q/projection/LabelledTasksViewProjection.java
@@ -90,11 +90,11 @@ public class LabelledTasksViewProjection extends Projection<LabelId,
     @Subscribe
     public void on(LabelRemovedFromTask event) {
         final LabelId labelId = event.getLabelId();
-        final boolean isEquals = getState().getLabelId()
-                                           .equals(labelId);
+        final boolean isEquals = getBuilder().getLabelId()
+                                             .equals(labelId);
         if (isEquals) {
-            final List<TaskItem> views = new ArrayList<>(getState().getLabelledTasks()
-                                                                   .getItemsList());
+            final List<TaskItem> views = new ArrayList<>(getBuilder().getLabelledTasks()
+                                                                     .getItemsList());
             final TaskListView updatedView = removeViewsByLabelId(views, labelId);
             getBuilder().setLabelledTasks(updatedView);
         }
@@ -102,16 +102,16 @@ public class LabelledTasksViewProjection extends Projection<LabelId,
 
     @Subscribe
     public void on(TaskDeleted event) {
-        final List<TaskItem> views = new ArrayList<>(getState().getLabelledTasks()
-                                                               .getItemsList());
+        final List<TaskItem> views = new ArrayList<>(getBuilder().getLabelledTasks()
+                                                                 .getItemsList());
         final TaskListView updatedView = removeViewsByTaskId(views, event.getTaskId());
         getBuilder().setLabelledTasks(updatedView);
     }
 
     @Subscribe
     public void on(TaskDescriptionUpdated event) {
-        final List<TaskItem> views = getState().getLabelledTasks()
-                                               .getItemsList();
+        final List<TaskItem> views = getBuilder().getLabelledTasks()
+                                                 .getItemsList();
         final List<TaskItem> updatedList = updateTaskItemList(views, event);
         final TaskListView taskListView = newTaskListView(updatedList);
         getBuilder().setLabelledTasks(taskListView);
@@ -119,8 +119,8 @@ public class LabelledTasksViewProjection extends Projection<LabelId,
 
     @Subscribe
     public void on(TaskPriorityUpdated event) {
-        final List<TaskItem> views = getState().getLabelledTasks()
-                                               .getItemsList();
+        final List<TaskItem> views = getBuilder().getLabelledTasks()
+                                                 .getItemsList();
         final List<TaskItem> updatedList = updateTaskItemList(views, event);
         final TaskListView taskListView = newTaskListView(updatedList);
         getBuilder().setLabelledTasks(taskListView);
@@ -128,8 +128,8 @@ public class LabelledTasksViewProjection extends Projection<LabelId,
 
     @Subscribe
     public void on(TaskDueDateUpdated event) {
-        final List<TaskItem> views = getState().getLabelledTasks()
-                                               .getItemsList();
+        final List<TaskItem> views = getBuilder().getLabelledTasks()
+                                                 .getItemsList();
         final List<TaskItem> updatedList = updateTaskItemList(views, event);
         final TaskListView taskListView = newTaskListView(updatedList);
         getBuilder().setLabelledTasks(taskListView);
@@ -137,8 +137,8 @@ public class LabelledTasksViewProjection extends Projection<LabelId,
 
     @Subscribe
     public void on(TaskCompleted event) {
-        final List<TaskItem> views = getState().getLabelledTasks()
-                                               .getItemsList();
+        final List<TaskItem> views = getBuilder().getLabelledTasks()
+                                                 .getItemsList();
         final List<TaskItem> updatedList = updateTaskItemList(views, event);
         final TaskListView taskListView = newTaskListView(updatedList);
         getBuilder().setLabelledTasks(taskListView);
@@ -146,8 +146,8 @@ public class LabelledTasksViewProjection extends Projection<LabelId,
 
     @Subscribe
     public void on(TaskReopened event) {
-        final List<TaskItem> views = getState().getLabelledTasks()
-                                               .getItemsList();
+        final List<TaskItem> views = getBuilder().getLabelledTasks()
+                                                 .getItemsList();
         final List<TaskItem> updatedList = updateTaskItemList(views, event);
         final TaskListView taskListView = newTaskListView(updatedList);
         getBuilder().setLabelledTasks(taskListView);
@@ -155,8 +155,8 @@ public class LabelledTasksViewProjection extends Projection<LabelId,
 
     @Subscribe
     public void on(LabelDetailsUpdated event) {
-        final List<TaskItem> views = getState().getLabelledTasks()
-                                               .getItemsList();
+        final List<TaskItem> views = getBuilder().getLabelledTasks()
+                                                 .getItemsList();
         final List<TaskItem> updatedList = updateTaskItemList(views, event);
         final TaskListView taskListView = newTaskListView(updatedList);
         final LabelDetails newDetails = event.getLabelDetailsChange()
@@ -190,8 +190,8 @@ public class LabelledTasksViewProjection extends Projection<LabelId,
     }
 
     private void addTaskItem(TaskItem taskView) {
-        final List<TaskItem> views = new ArrayList<>(getState().getLabelledTasks()
-                                                               .getItemsList());
+        final List<TaskItem> views = new ArrayList<>(getBuilder().getLabelledTasks()
+                                                                 .getItemsList());
         views.add(taskView);
         final TaskListView taskListView = newTaskListView(views);
         getBuilder().setLabelledTasks(taskListView);

--- a/api-java/src/main/java/io/spine/examples/todolist/q/projection/MyListViewProjection.java
+++ b/api-java/src/main/java/io/spine/examples/todolist/q/projection/MyListViewProjection.java
@@ -43,7 +43,6 @@ import io.spine.server.projection.Projection;
 import java.util.ArrayList;
 import java.util.List;
 
-import static io.spine.Identifier.newUuid;
 import static io.spine.examples.todolist.EnrichmentHelper.getEnrichment;
 import static io.spine.examples.todolist.q.projection.ProjectionHelper.newTaskListView;
 import static io.spine.examples.todolist.q.projection.ProjectionHelper.removeViewsByTaskId;
@@ -95,72 +94,72 @@ public class MyListViewProjection extends Projection<TaskListId, MyListView, MyL
 
     @Subscribe
     public void on(TaskDeleted event) {
-        final List<TaskItem> views = new ArrayList<>(getState().getMyList()
-                                                               .getItemsList());
+        final List<TaskItem> views = new ArrayList<>(getBuilder().getMyList()
+                                                                 .getItemsList());
         final TaskListView taskListView = removeViewsByTaskId(views, event.getTaskId());
         getBuilder().setMyList(taskListView);
     }
 
     @Subscribe
     public void on(TaskDescriptionUpdated event) {
-        final List<TaskItem> views = getState().getMyList()
-                                               .getItemsList();
+        final List<TaskItem> views = getBuilder().getMyList()
+                                                 .getItemsList();
         final List<TaskItem> updatedList = updateTaskItemList(views, event);
         updateMyListView(updatedList);
     }
 
     @Subscribe
     public void on(TaskPriorityUpdated event) {
-        final List<TaskItem> views = getState().getMyList()
-                                               .getItemsList();
+        final List<TaskItem> views = getBuilder().getMyList()
+                                                 .getItemsList();
         final List<TaskItem> updatedList = updateTaskItemList(views, event);
         updateMyListView(updatedList);
     }
 
     @Subscribe
     public void on(TaskDueDateUpdated event) {
-        final List<TaskItem> views = getState().getMyList()
-                                               .getItemsList();
+        final List<TaskItem> views = getBuilder().getMyList()
+                                                 .getItemsList();
         final List<TaskItem> updatedList = updateTaskItemList(views, event);
         updateMyListView(updatedList);
     }
 
     @Subscribe
     public void on(TaskCompleted event) {
-        final List<TaskItem> views = getState().getMyList()
-                                               .getItemsList();
+        final List<TaskItem> views = getBuilder().getMyList()
+                                                 .getItemsList();
         final List<TaskItem> updatedList = updateTaskItemList(views, event);
         updateMyListView(updatedList);
     }
 
     @Subscribe
     public void on(TaskReopened event) {
-        final List<TaskItem> views = getState().getMyList()
-                                               .getItemsList();
+        final List<TaskItem> views = getBuilder().getMyList()
+                                                 .getItemsList();
         final List<TaskItem> updatedList = updateTaskItemList(views, event);
         updateMyListView(updatedList);
     }
 
     @Subscribe
     public void on(LabelAssignedToTask event) {
-        final List<TaskItem> views = getState().getMyList()
-                                               .getItemsList();
+        final List<TaskItem> views = getBuilder().getMyList()
+                                                 .getItemsList();
         final List<TaskItem> updatedList = updateTaskItemList(views, event);
         updateMyListView(updatedList);
     }
 
     @Subscribe
     public void on(LabelRemovedFromTask event) {
-        final List<TaskItem> views = getState().getMyList()
-                                               .getItemsList();
+        final List<TaskItem> views = getBuilder().getMyList()
+                                                 .getItemsList();
         final List<TaskItem> updatedList = updateTaskItemList(views, event);
         updateMyListView(updatedList);
     }
 
     @Subscribe
     public void on(LabelDetailsUpdated event) {
-        final List<TaskItem> views = getState().getMyList()
-                                               .getItemsList();
+        final List<TaskItem> views = getBuilder().getMyList()
+                                                 .getItemsList();
         final List<TaskItem> updatedList = updateTaskItemList(views, event);
         updateMyListView(updatedList);
     }
@@ -187,8 +186,8 @@ public class MyListViewProjection extends Projection<TaskListId, MyListView, MyL
     }
 
     private void addTaskItem(TaskItem taskView) {
-        final List<TaskItem> views = new ArrayList<>(getState().getMyList()
-                                                               .getItemsList());
+        final List<TaskItem> views = new ArrayList<>(getBuilder().getMyList()
+                                                                 .getItemsList());
         views.add(taskView);
         final TaskListView taskListView = newTaskListView(views);
         getBuilder().setMyList(taskListView);

--- a/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/TaskLabelsPartTest.java
+++ b/api-java/src/test/java/io/spine/examples/todolist/c/aggregate/TaskLabelsPartTest.java
@@ -48,8 +48,10 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
+import java.util.Collection;
 import java.util.List;
 
+import static com.google.common.collect.ImmutableList.of;
 import static io.spine.Identifier.newUuid;
 import static io.spine.examples.todolist.testdata.TestLabelCommandFactory.createLabelInstance;
 import static io.spine.examples.todolist.testdata.TestTaskCommandFactory.DESCRIPTION;
@@ -59,6 +61,8 @@ import static io.spine.examples.todolist.testdata.TestTaskCommandFactory.deleteT
 import static io.spine.examples.todolist.testdata.TestTaskLabelsCommandFactory.assignLabelToTaskInstance;
 import static io.spine.examples.todolist.testdata.TestTaskLabelsCommandFactory.removeLabelFromTaskInstance;
 import static io.spine.server.aggregate.AggregateMessageDispatcher.dispatchCommand;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -98,7 +102,7 @@ class TaskLabelsPartTest {
 
         @Test
         @DisplayName("assign a label to the task")
-        void assignLabelToTask() {
+        void testAssignLabelToTask() {
             dispatchCommand(taskLabelsPart, CommandEnvelope.of(command().get()));
 
             final TaskLabels state = taskLabelsPart.getState();
@@ -148,7 +152,7 @@ class TaskLabelsPartTest {
         @DisplayName("produce LabelRemovedFromTask event")
         void produceEvent() throws CannotRemoveLabelFromTask {
             createBasicTask();
-            dispatchAssignLabelToTask();
+            assignLabelToTask();
 
             final List<? extends Message> messageList =
                     taskLabelsPart.handle(commandMessage().get());
@@ -167,7 +171,7 @@ class TaskLabelsPartTest {
         @DisplayName("remove a label from the task")
         void removeLabelFromTask() {
             createBasicTask();
-            dispatchAssignLabelToTask();
+            assignLabelToTask();
             final List<LabelId> labelIdsBeforeRemove = taskLabelsPart.getState()
                                                                      .getLabelIdsList()
                                                                      .getIdsList();
@@ -193,7 +197,7 @@ class TaskLabelsPartTest {
                 "upon an attempt to remove the label from the completed task")
         void cannotRemoveLabelFromCompletedTask() {
             createBasicTask();
-            dispatchAssignLabelToTask();
+            assignLabelToTask();
             completeTask();
 
             assertThrows(CannotRemoveLabelFromTask.class,
@@ -205,17 +209,38 @@ class TaskLabelsPartTest {
                 "upon an attempt to remove the label from the deleted task")
         void cannotRemoveLabelFromDeletedTask() {
             createBasicTask();
-            dispatchAssignLabelToTask();
+            assignLabelToTask();
             deleteTask();
 
             assertThrows(CannotRemoveLabelFromTask.class,
                          () -> taskLabelsPart.handle(commandMessage().get()));
         }
+    }
 
-        private void dispatchAssignLabelToTask() {
-            final AssignLabelToTask assignLabelToTask = assignLabelToTaskInstance(taskId, labelId);
-            final Command assignLabelToTaskCmd = createDifferentCommand(assignLabelToTask);
-            dispatchCommand(taskLabelsPart, CommandEnvelope.of(assignLabelToTaskCmd));
+    @Nested
+    @DisplayName("Multiple AssignLabelToTask commands should")
+    class AssignMultipleLabelsTest extends TaskLabelsCommandTest {
+
+        private final List<LabelId> labelIds = of(
+                createLabelId(), createLabelId(), createLabelId(), createLabelId()
+        );
+
+        @BeforeEach
+        @Override
+        protected void setUp() {
+            super.setUp();
+            labelIds.forEach(this::createLabel);
+            createBasicTask();
+            labelIds.forEach(this::assignLabelToTask);
+        }
+
+        @Test
+        @DisplayName("assign all labels to the task")
+        void testContainsAllLabels() {
+            final Collection<LabelId> actualLabels = taskLabelsPart.getState()
+                                                                   .getLabelIdsList()
+                                                                   .getIdsList();
+            assertThat(actualLabels, containsInAnyOrder(labelIds.toArray()));
         }
     }
 
@@ -247,6 +272,10 @@ class TaskLabelsPartTest {
         }
 
         private void createLabel() {
+            createLabel(labelId);
+        }
+
+        protected void createLabel(LabelId labelId) {
             final CreateBasicLabel createLabel = createLabelInstance(labelId);
             final Command createLabelCmd = createDifferentCommand(createLabel);
             commandBus.post(createLabelCmd, responseObserver);
@@ -268,6 +297,16 @@ class TaskLabelsPartTest {
             final CompleteTask completeTask = completeTaskInstance(taskId);
             final Command completeTaskCmd = createDifferentCommand(completeTask);
             commandBus.post(completeTaskCmd, responseObserver);
+        }
+
+        void assignLabelToTask() {
+            assignLabelToTask(labelId);
+        }
+
+        void assignLabelToTask(LabelId labelId) {
+            final AssignLabelToTask assignLabelToTask = assignLabelToTaskInstance(taskId, labelId);
+            final Command assignLabelToTaskCmd = createDifferentCommand(assignLabelToTask);
+            dispatchCommand(taskLabelsPart, CommandEnvelope.of(assignLabelToTaskCmd));
         }
 
         static LabelId createLabelId() {

--- a/integration-tests/src/test/java/io/spine/test/integration/TaskCreationWizardTest.java
+++ b/integration-tests/src/test/java/io/spine/test/integration/TaskCreationWizardTest.java
@@ -39,7 +39,9 @@ import org.junit.jupiter.api.Test;
 
 import static com.google.protobuf.util.Durations.fromSeconds;
 import static com.google.protobuf.util.Timestamps.add;
+import static io.spine.examples.todolist.LabelColor.BLUE;
 import static io.spine.examples.todolist.LabelColor.GRAY;
+import static io.spine.examples.todolist.LabelColor.GREEN;
 import static io.spine.examples.todolist.LabelColor.RED;
 import static io.spine.examples.todolist.TaskPriority.LOW;
 import static io.spine.examples.todolist.TaskStatus.DRAFT;
@@ -87,17 +89,28 @@ class TaskCreationWizardTest extends AbstractIntegrationTest {
         final TaskCreationId pid = newPid();
         final TaskId taskId = newTaskId();
         testEnv.createDraft(pid, taskId);
-        final String labelTitle = "red label";
-        final LabelDetails newLabel = LabelDetails.newBuilder()
-                                                  .setTitle(labelTitle)
+        final LabelDetails redLabel = LabelDetails.newBuilder()
+                                                  .setTitle("red label")
                                                   .setColor(RED)
                                                   .build();
+        final LabelDetails greenLabel = LabelDetails.newBuilder()
+                                                    .setTitle("green label")
+                                                    .setColor(GREEN)
+                                                    .build();
+        final LabelDetails blueLabel = LabelDetails.newBuilder()
+                                                   .setTitle("blue label")
+                                                   .setColor(GREEN)
+                                                   .build();
         final AddLabels addLabels = AddLabels.newBuilder()
                                              .setId(pid)
-                                             .addNewLabels(newLabel)
+                                             .addNewLabels(redLabel)
+                                             .addNewLabels(greenLabel)
+                                             .addNewLabels(blueLabel)
                                              .build();
         client.postCommand(addLabels);
-        assertAssignedLabel(taskId, labelTitle, RED);
+        assertAssignedLabel(taskId, redLabel.getTitle(), RED);
+        assertAssignedLabel(taskId, greenLabel.getTitle(), GREEN);
+        assertAssignedLabel(taskId, blueLabel.getTitle(), BLUE);
     }
 
     @Test

--- a/integration-tests/src/test/java/io/spine/test/integration/TaskCreationWizardTest.java
+++ b/integration-tests/src/test/java/io/spine/test/integration/TaskCreationWizardTest.java
@@ -91,6 +91,7 @@ class TaskCreationWizardTest extends AbstractIntegrationTest {
         final TaskCreationId pid = newPid();
         final TaskId taskId = newTaskId();
         testEnv.createDraft(pid, taskId);
+        testEnv.setDetails(pid, "secondCase");
         final LabelDetails redLabel = LabelDetails.newBuilder()
                                                   .setTitle("red label")
                                                   .setColor(RED)
@@ -101,7 +102,7 @@ class TaskCreationWizardTest extends AbstractIntegrationTest {
                                                     .build();
         final LabelDetails blueLabel = LabelDetails.newBuilder()
                                                    .setTitle("blue label")
-                                                   .setColor(GREEN)
+                                                   .setColor(BLUE)
                                                    .build();
         final AddLabels addLabels = AddLabels.newBuilder()
                                              .setId(pid)

--- a/integration-tests/src/test/java/io/spine/test/integration/TaskCreationWizardTest.java
+++ b/integration-tests/src/test/java/io/spine/test/integration/TaskCreationWizardTest.java
@@ -49,8 +49,10 @@ import static io.spine.examples.todolist.TaskStatus.FINALIZED;
 import static io.spine.test.integration.given.TaskCreationWizardTestEnv.newPid;
 import static io.spine.test.integration.given.TaskCreationWizardTestEnv.newTaskId;
 import static io.spine.time.Time.getCurrentTime;
+import static java.lang.String.format;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Dmytro Dashenkov
@@ -151,14 +153,20 @@ class TaskCreationWizardTest extends AbstractIntegrationTest {
 
     private void assertAssignedLabel(TaskId taskId, String labelTitle, LabelColor labelColor) {
         final String color = LabelColorView.valueOf(labelColor);
-        client.getLabelledTasksView()
-              .stream()
-              .filter(label -> labelTitle.equals(label.getLabelTitle()))
-              .peek(label -> assertTrue(color.equalsIgnoreCase(label.getLabelColor())))
-              .flatMap(label -> label.getLabelledTasks()
-                                     .getItemsList()
-                                     .stream())
-              .filter(task -> taskId.equals(task.getId()))
-              .findAny();
+        final boolean match = client.getLabelledTasksView()
+                                    .stream()
+                                    .filter(label -> labelTitle.equals(label.getLabelTitle()))
+                                    .peek(label -> {
+                                        final String actualColor = label.getLabelColor();
+                                        assertTrue(color.equalsIgnoreCase(actualColor));
+                                    })
+                                    .flatMap(label -> label.getLabelledTasks()
+                                                           .getItemsList()
+                                                           .stream())
+                                    .anyMatch(task -> taskId.equals(task.getId()));
+        if (!match) {
+            fail(format("Task %s has no label with title \"%s\" and color %s.",
+                        taskId.getValue(), labelTitle, labelColor));
+        }
     }
 }


### PR DESCRIPTION
In this PR we fix the event handlers (and command handlers in the procman).

Before the handlers used `getState()` to retrieve the current entity state, thus it turns out this is illegal. Now we use `getBuilder()` instead.

This PR fixes issue #49.

See [this issue](https://github.com/SpineEventEngine/core-java/issues/647) in `core-java` for the more detailed description of the bug reasons.