### PR TITLE
Authenticate requests to `spine-dev` database

### DIFF
--- a/client-web/lib/client.js
+++ b/client-web/lib/client.js
@@ -20,7 +20,7 @@
 
 let uuid = require("uuid");
 
-let client = require("spine-web-client/client/index.js").client;
+let client = require("spine-web-client/index.js").client;
 
 let TaskId = require("../proto/main/js/todolist/identifiers_pb").TaskId;
 let TaskDescription = require("../proto/main/js/todolist/values_pb").TaskDescription;

--- a/client-web/package.json
+++ b/client-web/package.json
@@ -9,7 +9,7 @@
   "author": "Spine Event Engine",
   "license": "Apache-2.0",
   "dependencies": {
-    "spine-web-client": "0.11.00-SNAPSHOT"
+    "spine-web-client": "1.0.0-SNAPSHOT"
   },
   "devDependencies": {
     "webpack": "^4.8.3",

--- a/deployment/local-web/src/main/java/io/spine/examples/todolist/server/Application.java
+++ b/deployment/local-web/src/main/java/io/spine/examples/todolist/server/Application.java
@@ -26,6 +26,9 @@ import io.spine.server.CommandService;
 import io.spine.server.QueryService;
 import io.spine.web.firebase.DatabaseUrl;
 import io.spine.web.firebase.FirebaseClient;
+import io.spine.web.firebase.FirebaseCredentials;
+
+import java.io.InputStream;
 
 import static io.spine.web.firebase.DatabaseUrl.from;
 import static io.spine.web.firebase.FirebaseClientFactory.restClient;
@@ -36,6 +39,7 @@ import static io.spine.web.firebase.FirebaseClientFactory.restClient;
 final class Application {
 
     private static final DatabaseUrl DATABASE_URL = from("https://spine-dev.firebaseio.com/");
+    private static final String SERVICE_ACCOUNT_FILE = "/spine-dev.json";
 
     private final QueryService queryService;
     private final CommandService commandService;
@@ -51,7 +55,9 @@ final class Application {
         this.commandService = CommandService.newBuilder()
                                             .add(boundedContext)
                                             .build();
-        this.firebaseClient = restClient(DATABASE_URL);
+        InputStream credentialStream = Application.class.getResourceAsStream(SERVICE_ACCOUNT_FILE);
+        FirebaseCredentials credentials = FirebaseCredentials.fromStream(credentialStream);
+        this.firebaseClient = restClient(DATABASE_URL, credentials);
     }
 
     /**

--- a/deployment/local-web/src/test/java/io/spine/examples/todolist/server/ApplicationTest.java
+++ b/deployment/local-web/src/test/java/io/spine/examples/todolist/server/ApplicationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2018, TeamDev. All rights reserved.
+ *
+ * Redistribution and use in source and/or binary forms, with or without
+ * modification, must retain the above copyright notice and the following
+ * disclaimer.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package io.spine.examples.todolist.server;
+
+import io.spine.examples.todolist.context.BoundedContexts;
+import io.spine.server.CommandService;
+import io.spine.server.QueryService;
+import io.spine.web.firebase.FirebaseClient;
+import io.spine.web.firebase.FirebaseCredentials;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@SuppressWarnings("DuplicateStringLiteralInspection") // Test display names duplication.
+@DisplayName("Application should")
+class ApplicationTest {
+
+    private Application application;
+
+    @BeforeEach
+    void setUp() {
+        application = new Application(BoundedContexts.create(), FirebaseCredentials.empty());
+    }
+
+    @Test
+    @DisplayName("return non-null QueryService")
+    void returnQueryService() {
+        QueryService queryService = application.queryService();
+        assertNotNull(queryService);
+    }
+
+    @Test
+    @DisplayName("return non-null CommandService")
+    void returnCommandService() {
+        CommandService commandService = application.commandService();
+        assertNotNull(commandService);
+    }
+
+    @Test
+    @DisplayName("return non-null FirebaseClient")
+    void returnFirebaseClient() {
+        FirebaseClient firebaseClient = application.firebaseClient();
+        assertNotNull(firebaseClient);
+    }
+}

--- a/version.gradle
+++ b/version.gradle
@@ -19,7 +19,7 @@
  */
 
 
-final def SPINE_VERSION = '1.0.0-pre1'
+final def SPINE_VERSION = '1.0.0-SNAPSHOT'
 
 project.ext {
     // To-do List app version
@@ -28,7 +28,7 @@ project.ext {
     // Spine dependencies' versions
     spineVersion = SPINE_VERSION
     spineJdbcStorageVersion = '1.0.0-pre1'
-    spineBaseVersion = '1.0.0-pre1'
+    spineBaseVersion = '1.0.0-SNAPSHOT'
     spineWebVersion = '1.0.0-SNAPSHOT'
 
     // Main scope third party dependencies' versions

--- a/version.gradle
+++ b/version.gradle
@@ -29,7 +29,7 @@ project.ext {
     spineVersion = SPINE_VERSION
     spineJdbcStorageVersion = '1.0.0-pre1'
     spineBaseVersion = '1.0.0-pre1'
-    spineWebVersion = '1.0.0-pre1'
+    spineWebVersion = '1.0.0-SNAPSHOT'
 
     // Main scope third party dependencies' versions
     servletApiVersion = '4.0.0'

--- a/version.gradle
+++ b/version.gradle
@@ -19,7 +19,7 @@
  */
 
 
-final def SPINE_VERSION = '1.0.0-SNAPSHOT'
+final def SPINE_VERSION = '1.0.0-pre1'
 
 project.ext {
     // To-do List app version
@@ -28,7 +28,7 @@ project.ext {
     // Spine dependencies' versions
     spineVersion = SPINE_VERSION
     spineJdbcStorageVersion = '1.0.0-pre1'
-    spineBaseVersion = '1.0.0-SNAPSHOT'
+    spineBaseVersion = '1.0.0-pre1'
     spineWebVersion = '1.0.0-SNAPSHOT'
 
     // Main scope third party dependencies' versions


### PR DESCRIPTION
This PR is a part of https://github.com/SpineEventEngine/web/pull/43.

The `spine-dev` Firebase database [rules](https://console.firebase.google.com/project/spine-dev/database/spine-dev/rules) have changed and now it is required to authenticate all write requests to its REST API.

For the authorization, we use service account file `spine-dev.json`, which is already present in the project.